### PR TITLE
✨ 동별 드랍된 음악 갯수 API 로직 추가

### DIFF
--- a/StreetDrop/NetworkManagerTest/NetworkManagerTest.swift
+++ b/StreetDrop/NetworkManagerTest/NetworkManagerTest.swift
@@ -110,4 +110,34 @@ final class NetworkManagerTest: XCTestCase {
         }
         .dispose()
     }
+    
+    func test_fetchNumberOfDroppedMusicByDong_success() {
+        //given
+        let address: String = "성남시 분당구 정자1동"
+        
+        //then 동별 드랍된 음악 갯수가 247이면 성공
+        var response: Data?
+        
+        sut.fetchNumberOfDroppedMusicByDong(address: address)
+            .subscribe {
+                switch $0 {
+                case .success(let data):
+                    response = data
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+            }
+            .dispose()
+        
+        do {
+            let numberOfDroppedMusicByDong = try JSONDecoder().decode(
+                NumberOfDroppedMusicByDongResponseDTO.self,
+                from: response ?? Data()
+            )
+
+            XCTAssertEqual(247, numberOfDroppedMusicByDong.numberOfDroppedMusic)
+        } catch {
+            XCTFail("Decoding Error")
+        }
+    }
 }

--- a/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
+++ b/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		040685092A01539800377094 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 040685082A01539800377094 /* Assets.xcassets */; };
 		0406850C2A01539800377094 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0406850A2A01539800377094 /* LaunchScreen.storyboard */; };
 		0410388E2A12688A00BC5532 /* DropMusicRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049F50212A122C8A001528CB /* DropMusicRequestDTO.swift */; };
+		041038972A126E7B00BC5532 /* NumberOfDroppedMusicByDongResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041038962A126E7B00BC5532 /* NumberOfDroppedMusicByDongResponseDTO.swift */; };
+		041038982A126E7B00BC5532 /* NumberOfDroppedMusicByDongResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041038962A126E7B00BC5532 /* NumberOfDroppedMusicByDongResponseDTO.swift */; };
 		049BC4262A02826400071A12 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 049BC4252A02826400071A12 /* RxCocoa */; };
 		049BC4282A02826400071A12 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 049BC4272A02826400071A12 /* RxRelay */; };
 		049BC42A2A02826400071A12 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 049BC4292A02826400071A12 /* RxSwift */; };
@@ -54,6 +56,7 @@
 		040685082A01539800377094 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0406850B2A01539800377094 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0406850D2A01539800377094 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		041038962A126E7B00BC5532 /* NumberOfDroppedMusicByDongResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberOfDroppedMusicByDongResponseDTO.swift; sourceTree = "<group>"; };
 		049F50212A122C8A001528CB /* DropMusicRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropMusicRequestDTO.swift; sourceTree = "<group>"; };
 		04FB1F252A0215BC0064B3C8 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		04FB1F272A021B0A0064B3C8 /* MainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainModel.swift; sourceTree = "<group>"; };
@@ -127,6 +130,14 @@
 				04FB1F232A0214B40064B3C8 /* Network */,
 			);
 			path = StreetDrop;
+			sourceTree = "<group>";
+		};
+		041038952A126D1400BC5532 /* NumberOfDroppedMusicByDong */ = {
+			isa = PBXGroup;
+			children = (
+				041038962A126E7B00BC5532 /* NumberOfDroppedMusicByDongResponseDTO.swift */,
+			);
+			path = NumberOfDroppedMusicByDong;
 			sourceTree = "<group>";
 		};
 		049F50242A122C8F001528CB /* DropMusic */ = {
@@ -255,6 +266,7 @@
 				41B953672A10E39D00BEC0AB /* SearchedMusicResponseDTO.swift */,
 				18F76FAF2A050133006CF9EF /* ResponseDTO.swift */,
 				049F50242A122C8F001528CB /* DropMusic */,
+				041038952A126D1400BC5532 /* NumberOfDroppedMusicByDong */,
 			);
 			path = DataMapping;
 			sourceTree = "<group>";
@@ -450,6 +462,7 @@
 				04FB1F282A021B0A0064B3C8 /* MainModel.swift in Sources */,
 				04FB1F262A0215BC0064B3C8 /* MainViewModel.swift in Sources */,
 				049F50222A122C8A001528CB /* DropMusicRequestDTO.swift in Sources */,
+				041038972A126E7B00BC5532 /* NumberOfDroppedMusicByDongResponseDTO.swift in Sources */,
 				04FB1F2D2A021BAB0064B3C8 /* DefaultTestRepository.swift in Sources */,
 				04FB1F2B2A021B8F0064B3C8 /* TestRepository.swift in Sources */,
 				41B953682A10E39D00BEC0AB /* SearchedMusicResponseDTO.swift in Sources */,
@@ -464,6 +477,7 @@
 				41FF59022A06B3A100ABB871 /* NetworkManager.swift in Sources */,
 				41FF59032A06B3A200ABB871 /* NetworkService.swift in Sources */,
 				0410388E2A12688A00BC5532 /* DropMusicRequestDTO.swift in Sources */,
+				041038982A126E7B00BC5532 /* NumberOfDroppedMusicByDongResponseDTO.swift in Sources */,
 				41B953692A10E5B800BEC0AB /* SearchedMusicResponseDTO.swift in Sources */,
 				41FF58FC2A06B38800ABB871 /* NetworkManagerTest.swift in Sources */,
 			);

--- a/StreetDrop/StreetDrop/Data/DataMapping/NumberOfDroppedMusicByDong/NumberOfDroppedMusicByDongResponseDTO.swift
+++ b/StreetDrop/StreetDrop/Data/DataMapping/NumberOfDroppedMusicByDong/NumberOfDroppedMusicByDongResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  NumberOfDroppedMusicByDongResponseDTO.swift
+//  StreetDrop
+//
+//  Created by Joseph Cha on 2023/05/15.
+//
+
+import Foundation
+
+struct NumberOfDroppedMusicByDongResponseDTO: Decodable {
+    let numberOfDroppedMusic: Int
+}

--- a/StreetDrop/StreetDrop/Network/NetworkManager.swift
+++ b/StreetDrop/StreetDrop/Network/NetworkManager.swift
@@ -36,4 +36,10 @@ struct NetworkManager {
             .retry(3)
             .map { $0.data }
     }
+    
+    func fetchNumberOfDroppedMusicByDong(address: String) -> Single<Data> {
+        return provider.rx.request(.fetchNumberOfDroppedMusicByDong(address: address))
+            .retry(3)
+            .map { $0.data }
+    }
 }

--- a/StreetDrop/StreetDrop/Network/NetworkService.swift
+++ b/StreetDrop/StreetDrop/Network/NetworkService.swift
@@ -13,6 +13,7 @@ enum NetworkService {
     case getWeather(lat: String, lon: String)
     case searchMusic(keyword: String)
     case dropMusic(requestDTO: DropMusicRequestDTO)
+    case fetchNumberOfDroppedMusicByDong(address: String)
 }
 
 extension NetworkService: TargetType {
@@ -20,9 +21,7 @@ extension NetworkService: TargetType {
         switch self {
         case .getWeather:
             return URL(string: "https://api.openweathermap.org")!
-        case .searchMusic:
-            return URL(string: "search.street-drop.com")!
-        case .dropMusic:
+        case .searchMusic, .dropMusic, .fetchNumberOfDroppedMusicByDong:
             return URL(string: "search.street-drop.com")!
         }
     }
@@ -40,7 +39,7 @@ extension NetworkService: TargetType {
         switch self {
         case .getWeather, .searchMusic:
             return .get
-        case .dropMusic:
+        case .dropMusic, .fetchNumberOfDroppedMusicByDong:
             return .post
         }
     }
@@ -59,6 +58,11 @@ extension NetworkService: TargetType {
                 encoding: URLEncoding.queryString)
         case .dropMusic(let dropRequestDTO):
             return .requestJSONEncodable(dropRequestDTO)
+        case .fetchNumberOfDroppedMusicByDong(let address):
+            return .requestParameters(
+                parameters: ["address": address],
+                encoding: URLEncoding.queryString
+            )
         }
     }
     
@@ -87,6 +91,12 @@ extension NetworkService: TargetType {
                         """.utf8)
         case .dropMusic:
             return Data()
+        case .fetchNumberOfDroppedMusicByDong:
+            return Data("""
+                        {
+                            "numberOfDroppedMusic": 247
+                        }
+                        """.utf8)
         }
     }
 }

--- a/StreetDrop/StreetDrop/Network/NetworkService.swift
+++ b/StreetDrop/StreetDrop/Network/NetworkService.swift
@@ -37,9 +37,9 @@ extension NetworkService: TargetType {
 
     var method: Moya.Method {
         switch self {
-        case .getWeather, .searchMusic:
+        case .getWeather, .searchMusic, .fetchNumberOfDroppedMusicByDong:
             return .get
-        case .dropMusic, .fetchNumberOfDroppedMusicByDong:
+        case .dropMusic:
             return .post
         }
     }


### PR DESCRIPTION
## 📌 배경

close #24 

## 내용
- 동별 드랍된 음악 갯수 API 로직 추가
- Stub을 이용한 API 테스트로직 추가

## 테스트 방법
- NetworkManagerTest 파일에서 test_fetchNumberOfDroppedMusicByDong_success() 테스트 실행하기

## 스크린샷
<img width="1552" alt="image" src="https://github.com/depromeet/street-drop-iOS/assets/35060252/91c9a789-4e60-40ab-b97a-1464dbfa08c6">
