### PR TITLE
✨검색 버튼 클릭 시 검색 API 호출, 음악 검색 화면 두가지 상황에서 키보드 hide

### DIFF
--- a/StreetDrop/StreetDrop/Application/SceneDelegate.swift
+++ b/StreetDrop/StreetDrop/Application/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = SearchingMusicViewController()
+        window?.rootViewController = MainViewController()
         window?.makeKeyAndVisible()
     }
 }

--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
@@ -52,6 +52,8 @@ final class SearchingMusicViewController: UIViewController {
         textField.textColor = UIColor(red: 0.867, green: 0.902, blue: 0.942, alpha: 1)
         textField.layer.cornerRadius = 8.0
         
+        textField.returnKeyType = .search
+        
         let leftPaddingView = UIView(
             frame: CGRect(
                 x: 0,
@@ -288,5 +290,13 @@ private extension SearchingMusicViewController {
             $0.top.equalTo(self.searchView.snp.bottom).offset(26)
             $0.leading.trailing.bottom.equalToSuperview()
         }
+    }
+}
+
+// MARK: - TextField
+extension SearchingMusicViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 }

--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
@@ -178,6 +178,7 @@ private extension SearchingMusicViewController {
                 self.searchTextField.text = recentQuery
                 self.tableView.isHidden = false
                 self.recentMusicSearchView.isHidden = true
+                self.searchTextField.resignFirstResponder()
             }
             .disposed(by: disposeBag)
     }

--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
@@ -174,7 +174,8 @@ private extension SearchingMusicViewController {
         self.recentMusicSearchScrollView.queryButtonDidTappedEvent
             .bind { recentQuery in
                 self.searchTextField.text = recentQuery
-                self.searchTextField.sendActions(for: .valueChanged)
+                self.tableView.isHidden = false
+                self.recentMusicSearchView.isHidden = true
             }
             .disposed(by: disposeBag)
     }
@@ -186,7 +187,8 @@ private extension SearchingMusicViewController {
         let input = DefaultSearchingMusicViewModel.Input(
             viewDidAppearEvent: .just(()),
             searchTextFieldDidEditEvent: self.searchTextField.rx.text.orEmpty,
-            keyBoardDidPressSearchEventWithKeyword: keyBoardDidPressSearchEventWithKeyword
+            keyBoardDidPressSearchEventWithKeyword: keyBoardDidPressSearchEventWithKeyword,
+            recentQueryDidPressEvent: self.recentMusicSearchScrollView.queryButtonDidTappedEvent
         )
         let output = viewModel.convert(input: input, disposedBag: disposeBag)
         

--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
@@ -147,6 +147,8 @@ final class SearchingMusicViewController: UIViewController {
             forCellReuseIdentifier: SearchingMusicTableViewCell.identifier
         )
         tableView.rowHeight = 76
+        tableView.keyboardDismissMode = .onDrag
+        
         return tableView
     }()
 }

--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/ViewModel/SearchingMusicViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/ViewModel/SearchingMusicViewModel.swift
@@ -24,6 +24,7 @@ final class DefaultSearchingMusicViewModel: SearchingMusicViewModel {
         let viewDidAppearEvent: Observable<Void>
         let searchTextFieldDidEditEvent: ControlProperty<String>
         let keyBoardDidPressSearchEventWithKeyword: Observable<String>
+        let recentQueryDidPressEvent: PublishRelay<String>
     }
     
     struct Output {
@@ -71,6 +72,12 @@ final class DefaultSearchingMusicViewModel: SearchingMusicViewModel {
             }
             .disposed(by: disposedBag)
                 
+        input.recentQueryDidPressEvent
+            .bind { [weak self] recentQuery in
+                self?.searchMusic(keyword: recentQuery)
+            }
+            .disposed(by: disposedBag)
+        
         self.searchedMusicList
             .bind(to: output.searchedMusicList)
             .disposed(by: disposedBag)


### PR DESCRIPTION
## 📌 배경

close #42
close #54  
close #70 
close #71 

## 내용
- 키보드의 검색 버튼 클릭 시, 검색 API 호출 하도록 수정
  - 또한 textField 공백일 경우, 키보드 검색 버튼 클릭시, 아무것도 동작안하도록 예외처리
- 기존엔 최근검색어 클릭시, textField text에 변경 이벤트가 들어와 API 호출했지만, 검색 버튼 클릭 시에만 API 호출하도록 변경됨에 따라 최근검색어 로직 변경
  - 기존엔 최근검색어 클릭시, textField text에 변경 이벤트가 들어와 API 호출했지만, 검색 버튼 클릭 시에만 API 호출하도록 변경됨에 따라 최근 검색어때도 API를 호출하는 메소드(searchMusic)를 따로 넣어둠
  - 최근 검색어 버튼 클릭시, 검색 결과 테이블 뷰 보이게하고, 최근 검색어 화면 히든 되도록 변경
- 음악 검색 테이블 뷰 스크롤 시, 키보드 hide 되도록 구현
- 음악 검색 화면에서, 키보드가 올라온 상태에서 최근 검색어 클릭 시, 키보드 hide 되도록 구현

## 테스트방법
```swift
import UIKit

class SceneDelegate: UIResponder, UIWindowSceneDelegate {

    var window: UIWindow?

    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
        guard let windowScene = (scene as? UIWindowScene) else { return }
        window = UIWindow(frame: UIScreen.main.bounds)
        window?.windowScene = windowScene
        window?.rootViewController = SearchingMusicViewController()
        window?.makeKeyAndVisible()
    }
}

```