### PR TITLE
✨동별 드랍 아이템 개수 조회 API Response 프로퍼티명 변경에 따른 변경점

### DIFF
--- a/StreetDrop/StreetDrop/Data/DataMapping/MusicCountByDong/MusicCountByDongResponseDTO+Mapping.swift
+++ b/StreetDrop/StreetDrop/Data/DataMapping/MusicCountByDong/MusicCountByDongResponseDTO+Mapping.swift
@@ -9,11 +9,11 @@ import Foundation
 
 struct MusicCountByDongResponseDTO: Decodable {
     let numberOfDroppedMusic: Int
-    let address: String
+    let villageName: String
 }
 
 extension MusicCountByDongResponseDTO {
     func toEntity() -> MusicCountEntity {
-        return .init(musicCount: numberOfDroppedMusic, address: address)
+        return .init(musicCount: numberOfDroppedMusic, villageName: villageName)
     }
 }

--- a/StreetDrop/StreetDrop/Network/NetworkService.swift
+++ b/StreetDrop/StreetDrop/Network/NetworkService.swift
@@ -74,9 +74,12 @@ extension NetworkService: TargetType {
                 encoding: URLEncoding.queryString)
         case .dropMusic(let dropRequestDTO):
             return .requestJSONEncodable(dropRequestDTO)
-        case .getMusicCountByDong(let address):
+        case .getMusicCountByDong(let latitude, let longitude):
             return .requestParameters(
-                parameters: ["name": address],
+                parameters: [
+                    "latitude": String(latitude),
+                    "longitude": String(longitude)
+                ],
                 encoding: URLEncoding.queryString
             )
         case .getMusicWithinArea(let lat, let lon, let distance):

--- a/StreetDrop/StreetDrop/Presentation/MainScene/Model/Entity/MusicCountEntity.swift
+++ b/StreetDrop/StreetDrop/Presentation/MainScene/Model/Entity/MusicCountEntity.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct MusicCountEntity {
     let musicCount: Int
-    let address: String
+    let villageName: String
 }

--- a/StreetDrop/StreetDrop/Presentation/MainScene/ViewModel/MainViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/MainScene/ViewModel/MainViewModel.swift
@@ -169,7 +169,7 @@ private extension MainViewModel {
                 switch result {
                 case .success(let musicCountEntity):
                     output.musicCount.accept(musicCountEntity.musicCount)
-                    output.address.accept(musicCountEntity.address)
+                    output.address.accept(musicCountEntity.villageName)
                 case .failure(_):
                     output.musicCount.accept(0)
                 }


### PR DESCRIPTION
## 📌 배경

close #107 

## 내용
- 머지 컨플리트 해결 시, 잘못 수정된 부분 재수정
- 동별 드랍 아이템 개수 조회 API Response 프로퍼티명 변경에 따라, DTO 및 Entity 프로퍼티명 변경
  - DTO의 경우, Decodable에 의해 response 프로퍼티명과 같아야함

## 스크린샷 
**지도 움직일떄마다, 해당 지역의 메인화면 상단의 주소랑 드랍된 갯수 잘 뜸**

![image](https://github.com/depromeet/street-drop-iOS/assets/35060252/641405bc-bdf9-404d-8d79-f7efb353c0b4)

