### PR TITLE
✨지도 줌인/줌아웃 활성화 및 줌인/줌아웃에 따른 축척 변화에 맞춰 500m 반경 원 UI 크기 변경

### DIFF
--- a/StreetDrop/StreetDrop/Presentation/MainScene/View/MainViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/MainScene/View/MainViewController.swift
@@ -75,8 +75,6 @@ final class MainViewController: UIViewController {
         let mapView = NMFMapView()
         mapView.mapType = .navi
         mapView.isNightModeEnabled = true
-        mapView.minZoomLevel = 14.0
-        mapView.maxZoomLevel = 14.0
         mapView.addCameraDelegate(delegate: self)
         return mapView
     }()
@@ -650,5 +648,9 @@ extension MainViewController: Alertable {
 extension MainViewController: NMFMapViewCameraDelegate {
     func mapViewCameraIdle(_ mapView: NMFMapView) {
         self.cameraDidStopEvent.accept((mapView.latitude, mapView.longitude))
+    }
+    
+    func mapView(_ mapView: NMFMapView, cameraIsChangingByReason reason: Int) {
+        self.locationOverlay.circleRadius = circleRadius / naverMapView.projection.metersPerPixel()
     }
 }


### PR DESCRIPTION
## 📌 배경

close #134 

## 내용
- 지도 줌인/줌아웃 활성화
- 줌인/줌아웃에 따른 축척 변화에 맞춰 500m 반경 원 UI 크기 변경

## 스크린샷 (optional)

|줌인 원크기|줌아웃 원크기|
|:-:|:-:|
|<img width=300 src="https://github.com/depromeet/street-drop-iOS/assets/35060252/53f19214-9dba-4ccc-97b8-59538ac4487e">|<img width=300 src="https://github.com/depromeet/street-drop-iOS/assets/35060252/e60ae116-e004-4e9e-830e-5d07be76590d">|