### PR TITLE
♻️ 커뮤니티화면 데이터 3개 이하 무한스크롤 제거 (메인화면 변경 미포함)

### DIFF
--- a/StreetDrop/StreetDrop/Presentation/CommunityView/View/AlbumCollectionViewCell.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/View/AlbumCollectionViewCell.swift
@@ -24,19 +24,6 @@ final class AlbumCollectionViewCell: UICollectionViewCell {
         return imageView
     }()
 
-    private let gradationView: UIView = {
-        let view = UIView()
-//        view.layer.borderColor = UIColor.white.cgColor
-//        view.layer.borderWidth = 0
-//        view.layer.shadowOpacity = 1
-//        view.layer.shadowColor = UIColor.primary500.cgColor
-//        view.layer.shadowOffset = CGSize(width: 0, height: 0)
-//        view.layer.shadowRadius = 10
-//        view.layer.masksToBounds = false
-
-        return view
-    }()
-
     private func configureHierarchy() {
         self.contentView.addSubview(albumImageView)
     }

--- a/StreetDrop/StreetDrop/Presentation/CommunityView/View/AlbumCollectionViewCell.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/View/AlbumCollectionViewCell.swift
@@ -54,6 +54,10 @@ final class AlbumCollectionViewCell: UICollectionViewCell {
     }
 
     func setData(_ albumImageURL: String) {
+        guard !albumImageURL.isEmpty  else {
+            return
+        }
+
         self.albumImageView.setImage(with: albumImageURL, disposeBag: disposeBag)
     }
 

--- a/StreetDrop/StreetDrop/Presentation/CommunityView/View/CommunityViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/View/CommunityViewController.swift
@@ -586,10 +586,12 @@ private extension CommunityViewController {
 // MARK: - 무한스크롤
 extension CommunityViewController: UICollectionViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard let layout = self.albumCollectionView.collectionViewLayout
+        // 데이터가 4개이상일 때만 무한스크롤
+        guard viewModel.communityInfos.count > 3,
+              let layout = self.albumCollectionView.collectionViewLayout
                 as? UICollectionViewFlowLayout else { return }
 
-        let count = viewModel.communityInfoCount
+        let count = viewModel.communityInfos.count
         let cellWidth = layout.itemSize.width
 
         if scrollView.contentOffset.x < cellWidth {
@@ -633,7 +635,15 @@ extension CommunityViewController: UICollectionViewDelegate {
             y: 0
         )
 
-        changedAlbumCollectionViewIndexEvent.accept(index+1) //offset0일때, 0번 앨범이아니라 1번앨범내용이므로 index+1
+        // 스크롤뷰 offset 0일때, 0번 앨범이아니라 1번 앨범이 가운데이므로 기본으로 index+1 과 씽크를 맞춰야 하지만,
+        // 데이터가 2,3개일 때는 무한스크롤없이 첫번째/마지막쎌이 가운데로 스크롤되게하기위해 처음/마지막에 빈쎌을 넣어준상태
+        // 즉 데이터가 3개면 Cell은 빈쎌+3개+빈쎌 = 5개로 만져놓은상태로 스크롤뷰 offset0일 때 == 데이터 인덱스는 0이 가운데
+        if (2...3).contains(viewModel.communityInfos.count) {
+            changedAlbumCollectionViewIndexEvent.accept(index)
+        } else {
+            changedAlbumCollectionViewIndexEvent.accept(index+1)
+        }
+
     }
 
     private func setupInitialOffset(index: Int) {

--- a/StreetDrop/StreetDrop/Presentation/CommunityView/View/CommunityViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/View/CommunityViewController.swift
@@ -34,7 +34,6 @@ final class CommunityViewController: UIViewController {
         configureUI()
         bindAction()
         bindViewModel()
-        setupInitialOffset()
         viewDidLoadEvent.accept(())
     }
 
@@ -305,6 +304,12 @@ private extension CommunityViewController {
             .asDriver(onErrorJustReturn: "")
             .drive { [weak self] in
                 self?.locationLabel.text = $0
+            }.disposed(by: disposeBag)
+
+        output.currentIndex
+            .asDriver(onErrorJustReturn: 0)
+            .drive {  [weak self] in
+                self?.setupInitialOffset(index: $0)
             }.disposed(by: disposeBag)
 
         output.musicTitle
@@ -631,15 +636,14 @@ extension CommunityViewController: UICollectionViewDelegate {
         changedAlbumCollectionViewIndexEvent.accept(index+1) //offset0일때, 0번 앨범이아니라 1번앨범내용이므로 index+1
     }
 
-    // 4,5 + (1...5) + 1,2 로 들어오므로 1이 가운데에오도록 처음 offset지정
-    private func setupInitialOffset() {
+    private func setupInitialOffset(index: Int) {
         guard let layout = self.albumCollectionView.collectionViewLayout
                 as? UICollectionViewFlowLayout else { return }
+        albumCollectionView.layoutIfNeeded()
 
         let cellWidth = layout.itemSize.width
-
         albumCollectionView.setContentOffset(
-            CGPoint(x: cellWidth, y: .zero),
+            CGPoint(x: (cellWidth * CGFloat(index - 1)), y: .zero),
             animated: false
         )
     }

--- a/StreetDrop/StreetDrop/Presentation/CommunityView/ViewModel/CommunityViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/ViewModel/CommunityViewModel.swift
@@ -20,6 +20,7 @@ final class CommunityViewModel: ViewModel {
 
     struct Output {
         var addressTitle: PublishRelay<String> = .init()
+        var currentIndex: PublishRelay<Int> = .init()
         var albumImages: PublishRelay<[String]> = .init()
         var musicTitle: PublishRelay<String> = .init()
         var artistTitle: PublishRelay<String> = .init()
@@ -50,8 +51,6 @@ final class CommunityViewModel: ViewModel {
         self.communityInfos = communityInfos
         self.currentIndex = index
         self.communityModel = communityModel
-
-        prepareInfiniteCarousel()
     }
 
     func convert(input: Input, disposedBag: RxSwift.DisposeBag) -> Output {
@@ -62,6 +61,7 @@ final class CommunityViewModel: ViewModel {
                 guard let self = self else { return }
                 output.addressTitle.accept(self.communityInfos[self.currentIndex].address)
                 output.albumImages.accept(self.communityInfos.map { $0.albumImageURL })
+                output.currentIndex.accept(self.currentIndex)
                 self.changeCommunityInfoForIndex(index: self.currentIndex, output: output)
             }).disposed(by: disposedBag)
 
@@ -90,26 +90,6 @@ final class CommunityViewModel: ViewModel {
 
 //MARK: - Private
 private extension CommunityViewModel {
-
-    func prepareInfiniteCarousel() {
-        let newCommunityInfosFront = Array(communityInfos[
-            currentIndex...communityInfos.count-1
-        ])
-
-        let newCommunityInfosBack = Array(communityInfos[
-            0...(currentIndex-1)
-        ])
-
-        communityInfos = newCommunityInfosFront + newCommunityInfosBack
-        
-        // 데이터 앞 뒤2개씩 추가: origin 1,2,3,4,5 -> to be 4,5 + 1,2,3,4,5 + 1,2
-        communityInfos.insert(communityInfos[communityInfos.count-1], at: 0)
-        communityInfos.insert(communityInfos[communityInfos.count-2], at: 0)
-        communityInfos.append(communityInfos[2])
-        communityInfos.append(communityInfos[3])
-        currentIndex = 2
-    }
-
     func changeCommunityInfoForIndex(index: Int, output: Output) {
         let communityInfo = communityInfos[index]
 


### PR DESCRIPTION

## 📌 배경

close #130의 절반 (절반은 메인화면 중규님 진행중)

## 내용
- 커뮤니티화면에서 데이터가 3개 이하일 땐, 앨범 컬렉션이 무한스크롤을 없앴습니다.
    1. 데이터가 한개일 때
         👉 컬렉션뷰 레이아웃이 자동으로 하나의 셀을 가운데로 레이아웃
    2. 데이터가 2,3개일 때
         👉 1번앨범도 스크롤해서 화면의 가운데로 오게 만들어야하는데, 쎌 갯수가 부족해서 스크롤 되지않는 문제가 있었습니다.
             (정확히 말하면,, 컬렉션뷰의 스크롤 Bounds가 Frame보다 크지않아 dequeue 할 Cell이 더 없어서 스크롤 되지않는 문제)
             화면 UI 모양으론 -> | [ 앨범1쎌] [ 앨범2쎌 ] [ 3쎌 절반 ] |   이상태로 스크롤 불가능한 상태가됩니다.
             그래서 데이터가 2, 3개일 때는 맨앞, 맨끝에 빈 Cell을 넣는 방법으로 구현했습니다.
             이렇게하면 실제 첫번째 앨범이 가운데에 올때 UI상태는 | [ 투명쎌절반 ] [ 앨범 1 ] [ 앨범2절반 ] | 모양으로 UI를 갖게되고 
             그림처럼 앨범1이 가운데에 올 수 있게했습니다. 
             
스크롤 없애는 방식이 중규님과 로직과 좀 달라서 설명이 이해가 안가시면 댓글 달아주세욥 ㅜㅡㅜ...!

## 스크린샷 (optional)

- 1개일 때
    <img width = 300 src = "https://github.com/depromeet/street-drop-iOS/assets/107384230/97dc348c-0657-43de-bfc6-9a002403c4ae" >

- 2개일 때
 <img width = 300 src = "https://github.com/depromeet/street-drop-iOS/assets/107384230/78a91ab7-a30c-487b-a520-2ffa9a70f2b1" >

- 3개일 때
 <img width = 300 src = "https://github.com/depromeet/street-drop-iOS/assets/107384230/b2a49c69-fda6-4305-88f5-8300088d1f89" >


## 테스트 방법 (optional)
SecneDelegate에 임의 데이터 지정
```swift
import UIKit

class SceneDelegate: UIResponder, UIWindowSceneDelegate {

    var window: UIWindow?

    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
        guard let windowScene = (scene as? UIWindowScene) else { return }
        window = UIWindow(frame: UIScreen.main.bounds)
        window?.windowScene = windowScene

        let info1 = MusicWithinAreaEntity(
            id: 1,
            userName: "user3",
            userProfileImageURL: "",
            musicApp: "",
            address: "미추홀구 용현1.4동",
            musicTitle: "LAST DANCE",
            artist: "BIGBANG",
            albumImageURL: "https://is5-ssl.mzstatic.com/image/thumb/Music125/v4/5b/9b/8e/5b9b8ef2-998e-1210-8454-dfebfbf6271c/BB_COVER_IMAGE_4000.jpg/500x500bb.jpg",
            genre: ["K-Pop", "음악", "팝"],
            content: "1111아 죽곡수핑ㄹ누밍라운ㅁ림",
            createdAt: "2023-05-21 01:13:14",
            isLiked: true,
            likeCount: 14
        )

        let info2 = MusicWithinAreaEntity(
            id: 1,
            userName: "user3",
            userProfileImageURL: "",
            musicApp: "",
            address: "미추홀구 용현1.4동",
            musicTitle: "LAST DANCE",
            artist: "BIGBANG",
            albumImageURL: "https://is5-ssl.mzstatic.com/image/thumb/Music125/v4/5b/9b/8e/5b9b8ef2-998e-1210-8454-dfebfbf6271c/BB_COVER_IMAGE_4000.jpg/500x500bb.jpg",
            genre: ["K-Pop", "음악", "팝"],
            content: "22222아 죽곡수핑ㄹ누밍라운ㅁ림\n아 죽곡수핑ㄹ누밍라운ㅁ림\n아 죽곡수핑ㄹ누밍라운ㅁ림\n아 죽곡수핑ㄹ누밍라운ㅁ림\n아 죽곡수핑ㄹ누밍라운ㅁ림",
            createdAt: "2023-05-21 01:13:14",
            isLiked: true,
            likeCount: 14
        )

        let info3 = MusicWithinAreaEntity(
            id: 1,
            userName: "user3",
            userProfileImageURL: "",
            musicApp: "",
            address: "미추홀구 용현1.4동",
            musicTitle: "LAST DANCE",
            artist: "BIGBANG",
            albumImageURL: "https://is5-ssl.mzstatic.com/image/thumb/Music125/v4/5b/9b/8e/5b9b8ef2-998e-1210-8454-dfebfbf6271c/BB_COVER_IMAGE_4000.jpg/500x500bb.jpg",
            genre: ["K-Pop", "음악", "팝"],
            content: "33333아 죽곡수핑ㄹ누밍라운ㅁ림",
            createdAt: "2023-05-21 01:13:14",
            isLiked: true,
            likeCount: 14
        )

        let communityViewController = CommunityViewController(
            viewModel: CommunityViewModel(
                communityInfos: [info1, info2, info3],
                index: 2)
        )

        window?.rootViewController = communityViewController
        window?.makeKeyAndVisible()
    }
}
```