### PR TITLE
🐛음악 검색 텍스트 뷰 공백일 경우, 이전 검색어에대한 테이블뷰 정보 지우도록 수정

### DIFF
--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
@@ -195,9 +195,13 @@ private extension SearchingMusicViewController {
         
         let selectedTableViewCellEvent = self.tableView.rx.itemSelected.map { $0.row }
         
+        let searchTextFieldEmptyEvent = self.searchTextField.rx.text.orEmpty.filter{
+            $0.isEmpty
+        }.map { _ in }
+        
         let input = DefaultSearchingMusicViewModel.Input(
             viewDidAppearEvent: .just(()),
-            searchTextFieldDidEditEvent: self.searchTextField.rx.text.orEmpty,
+            searchTextFieldEmptyEvent: searchTextFieldEmptyEvent,
             keyBoardDidPressSearchEventWithKeyword: keyBoardDidPressSearchEventWithKeyword,
             recentQueryDidPressEvent: self.recentMusicSearchScrollView.queryButtonDidTappedEvent,
             tableViewCellDidPressedEvent: selectedTableViewCellEvent

--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/ViewModel/SearchingMusicViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/ViewModel/SearchingMusicViewModel.swift
@@ -21,12 +21,11 @@ final class DefaultSearchingMusicViewModel: SearchingMusicViewModel {
     let location: CLLocation
     let address: String
     private let disposeBag: DisposeBag = DisposeBag()
-    let searchedMusicList: PublishRelay = PublishRelay<[Music]>()
     private var musicList: [Music] = []
     
     struct Input {
         let viewDidAppearEvent: Observable<Void>
-        let searchTextFieldDidEditEvent: ControlProperty<String>
+        let searchTextFieldEmptyEvent: Observable<Void>
         let keyBoardDidPressSearchEventWithKeyword: Observable<String>
         let recentQueryDidPressEvent: PublishRelay<String>
         let tableViewCellDidPressedEvent: Observable<Int>
@@ -66,12 +65,9 @@ final class DefaultSearchingMusicViewModel: SearchingMusicViewModel {
             })
             .disposed(by: disposedBag)
         
-        input.searchTextFieldDidEditEvent
-            .bind { [weak self] keyword in
-                // 검색어가 공백일 경우, 뮤직리스트 빈값으로 설정
-                if keyword.isEmpty {
-                    self?.searchedMusicList.accept([])
-                }
+        input.searchTextFieldEmptyEvent
+            .bind {
+                output.searchedMusicList.accept([])
             }
             .disposed(by: disposedBag)
         


### PR DESCRIPTION
## 📌 배경

close #152 

## 내용
- 음악 검색 텍스트 뷰 공백일 경우, 이전 검색어에대한 테이블뷰 정보 지우도록 수정

## 테스트 방법 (optional)
- 음악 검색 후, 검색 텍스트뷰 공백으로 만들고 다시 타이핑 시, 이전 검색에 대한 테이블뷰 셀들이 사라지는지 확인