### PR TITLE
Feature/data 세개 이하 인덱스문제

### DIFF
--- a/StreetDrop/StreetDrop/Presentation/CommunityView/ViewModel/CommunityViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/ViewModel/CommunityViewModel.swift
@@ -61,9 +61,9 @@ final class CommunityViewModel: ViewModel {
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
 
-                // 데이터가 2,3개일 때는 무한스크롤없이 첫번째/마지막쎌이 가운데로 스크롤되게하기위해 처음/마지막에 빈쎌을 넣어준상태
+                // 데이터가 1~3개일 때는 무한스크롤없이 첫번째/마지막쎌이 가운데로 스크롤되게하기위해 처음/마지막에 빈쎌을 넣어준상태
                 // ex [1, 2, 3]  ===>>> [ ] + [1, 2, 3] + [ ]
-                if (2...3).contains(self.communityInfos.count) {
+                if (1...3).contains(self.communityInfos.count) {
                     self.addEmptyInfoAtEachEnd()
                     self.currentIndex += 1
                 }
@@ -103,24 +103,6 @@ final class CommunityViewModel: ViewModel {
                 output.isMyDrop.accept(myUserID == MusicInfoUserID)
 
             }).disposed(by: disposedBag)
-    /*
-     optionButton.rx.tap
-         .observe(on: MainScheduler.instance)
-         .subscribe(onNext: { [weak self] in
-             guard let self = self else { return }
-
-             let optionModalViewModel = OptionModalViewModel(
-                 itemId: self.viewModel.communityInfos[self.viewModel.currentIndex].id,
-                 musicIndex: self.viewModel.currentIndex
-             )
-             optionModalViewModel.delegate = self
-
-             let modalView = OptionModalViewController(viewModel: optionModalViewModel)
-             modalView.modalPresentationStyle = .overCurrentContext
-             self.navigationController?.present(modalView, animated: true)
-         })
-         .disposed(by: disposeBag)
-     */
 
         input.deleteEvent
             .subscribe(onNext: { [weak self] index in
@@ -144,7 +126,8 @@ final class CommunityViewModel: ViewModel {
 //MARK: - Private
 private extension CommunityViewModel {
     func changeCommunityInfoForIndex(index: Int, output: Output) {
-        guard (1..<communityInfos.count-1).contains(index) else { return }
+        guard (0..<communityInfos.count).contains(index),
+              communityInfos[index].albumImageURL != "" else { return }
 
         let communityInfo = communityInfos[index]
 

--- a/StreetDrop/StreetDrop/Presentation/CommunityView/ViewModel/CommunityViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/ViewModel/CommunityViewModel.swift
@@ -60,15 +60,16 @@ final class CommunityViewModel: ViewModel {
         input.viewDidLoadEvent
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
-                output.addressTitle.accept(self.communityInfos[self.currentIndex].address)
-                self.changeCommunityInfoForIndex(index: self.currentIndex, output: output)
 
                 // 데이터가 2,3개일 때는 무한스크롤없이 첫번째/마지막쎌이 가운데로 스크롤되게하기위해 처음/마지막에 빈쎌을 넣어준상태
                 // ex [1, 2, 3]  ===>>> [ ] + [1, 2, 3] + [ ]
                 if (2...3).contains(self.communityInfos.count) {
                     self.addEmptyInfoAtEachEnd()
+                    self.currentIndex += 1
                 }
-
+                
+                output.addressTitle.accept(self.communityInfos[self.currentIndex].address)
+                self.changeCommunityInfoForIndex(index: self.currentIndex, output: output)
                 let albumImagesURL = self.communityInfos.map { $0.albumImageURL }
                 output.albumImages.accept(albumImagesURL)
                 output.currentIndex.accept(self.currentIndex)


### PR DESCRIPTION
## 📌 배경

close #168 

## 내용
**- 크래쉬문제 해결**
🐛 3개 이할일 때, 커뮤니티뷰 넘어갈 때 크래쉬나는 문제가 있었습니다.

원인은,
데이터가 3개 이할일 때, 무한스크롤 없이 Cell이 가운데로 오게 하기 위해 데이터 앞 뒤로  빈Cell 을 넣었었는데,
커뮤니티뷰에서 스크롤할 때 빈Cell과 코멘트텍스트뷰가 바인딩되는 것을 막기위해 guard문을 설치했었습니다.
```swift
guard (1..<communityInfos.count-1).contains(index) else { return }
```
여기서 index가 0 일때(=데이터가 1개일때)는 `1..<0 `의 범위가되서 crash 났었습니다.

guard문에서 index 범위를 아래와같이 바꾸고, 빈Cell과 바인딩되는것을 막기위해 들어온 index에 있는 albumImageURL 이 빈값이면 return 되도록 수정했습니다
```swift
 guard (0..<communityInfos.count).contains(index),
       communityInfos[index].albumImageURL != "" else { return }
 ```
 
- 🐛 삭제 안정성 확인

테스트 경우의 수

1. 4개 초과일 때, 마지막 index 삭제 (기대값: 0번 Cell로 이동후 무한스크롤 O)
2. 4개 초과일 때, 첫번째 index 삭제 (기대값: 오른쪽Cell로 이동후 무한스크롤 O)
3. 4개 초과일 때, 가운데 index 삭제 (기대값: 오른쪽Cell로 이동후 무한스크롤 O) 

<br>

4. 4개일 때, 마지막 index 삭제 (기대값: 왼쪽Cell로 이동, 무한스크롤 X)
5. 4개일 때, 첫번째 index 삭제 (기대값: 오른쪽Cell로 이동, 무한스크롤 X)
6. 4개일 때, 가운데 index 삭제 (기대값: 오른쪽Cell로 이동, 무한스크롤 X) 

<br>

7. 3개일 때, 마지막 index 삭제 (기대값: 왼쪽Cell로 이동, 무한스크롤 X)
8. 3개일 때, 첫번째 index 삭제 (기대값: 오른쪽Cell로 이동, 무한스크롤 X)
9. 3개일 때, 가운데 index 삭제 (기대값: 오른쪽Cell로 이동, 무한스크롤 X) 

<br>

10. 2개일 때, 마지막 index 삭제 (기대값: 왼쪽Cell로 이동, 무한스크롤 X)
11. 2개일 때, 첫번째 index 삭제 (기대값: 오른쪽Cell로 이동, 무한스크롤 X) 

<br>

12. 1개일 때, 삭제(기대값: dismiss)

