### PR TITLE
🐛 장르 라벨 많을 때, 옵션버튼 가림문제해결

### DIFF
--- a/StreetDrop/StreetDrop/Presentation/CommunityView/View/CommunityViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/View/CommunityViewController.swift
@@ -613,7 +613,13 @@ private extension CommunityViewController {
 
 private extension CommunityViewController {
     func generateGenreLabels(genres: [String]) -> [PaddingLabel] {
+        var genres = genres
         var labels: [PaddingLabel] = []
+
+        if genres.count > 3 {
+            genres = Array(genres[0..<3])
+        }
+
         genres.forEach { genreTitle in
             let label = PaddingLabel(padding: UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12))
             label.text = genreTitle


### PR DESCRIPTION
## 📌 배경

close #167 

와 드디어 애자일한 PR이다...!

## 내용
- 장르 갯수 많을 때 옵션버튼 가림문제
<img width="215" alt="스크린샷 2023-07-08 오후 3 14 58" src="https://github.com/depromeet/street-drop-iOS/assets/107384230/4684d772-6ad0-41f4-9907-c7b4717b9d0d">

👉 데이터로 내려오는 장르 갯수가 3개이상일 때, 3개로 제한 (디자인팀 협의완료)
<img width="392" alt="스크린샷 2023-07-08 오후 3 16 11" src="https://github.com/depromeet/street-drop-iOS/assets/107384230/e6421d31-dfa9-448f-85c2-f9c7aea91e6b">


## 테스트 방법 (optional)
- jill Scott - Golden 노래 드랍 후 확인 (스샷의 주인공, 문제를 발견하게 해 준 case였습니다)

## 스크린샷 (optional)
<img width="236" alt="스크린샷 2023-07-08 오후 3 17 21" src="https://github.com/depromeet/street-drop-iOS/assets/107384230/8dd68ac8-36e6-4fdc-83d1-3e65d3c8ad71">