### PR TITLE
✨ Alert 커스텀

### DIFF
--- a/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
+++ b/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		41589AB82A46D82F0029A2EE /* DropAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41589AB72A46D82F0029A2EE /* DropAnimationView.swift */; };
 		41589ABA2A474B3D0029A2EE /* CommunityGuideDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41589AB92A474B3D0029A2EE /* CommunityGuideDetailView.swift */; };
 		41A3DDEB2A58428F004CFA2F /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A3DDEA2A58428F004CFA2F /* ToastView.swift */; };
+		41A3DDF12A593ED4004CFA2F /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A3DDF02A593ED4004CFA2F /* AlertViewController.swift */; };
 		41A9BEB02A4AF45300F3605C /* ClaimModalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A9BEAF2A4AF45300F3605C /* ClaimModalViewModel.swift */; };
 		41A9BEB72A4DC6CE00F3605C /* ClaimCommentRequestDTO+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A9BEB62A4DC6CE00F3605C /* ClaimCommentRequestDTO+Mapping.swift */; };
 		41A9BEB92A4DCA4A00F3605C /* ClaimCommentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A9BEB82A4DCA4A00F3605C /* ClaimCommentRepository.swift */; };
@@ -241,6 +242,7 @@
 		41589AB72A46D82F0029A2EE /* DropAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropAnimationView.swift; sourceTree = "<group>"; };
 		41589AB92A474B3D0029A2EE /* CommunityGuideDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityGuideDetailView.swift; sourceTree = "<group>"; };
 		41A3DDEA2A58428F004CFA2F /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
+		41A3DDF02A593ED4004CFA2F /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		41A9BEAF2A4AF45300F3605C /* ClaimModalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimModalViewModel.swift; sourceTree = "<group>"; };
 		41A9BEB62A4DC6CE00F3605C /* ClaimCommentRequestDTO+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClaimCommentRequestDTO+Mapping.swift"; sourceTree = "<group>"; };
 		41A9BEB82A4DCA4A00F3605C /* ClaimCommentRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimCommentRepository.swift; sourceTree = "<group>"; };
@@ -752,10 +754,11 @@
 			isa = PBXGroup;
 			children = (
 				415113292A16635D0051F809 /* Extension */,
-				41A3DDEA2A58428F004CFA2F /* ToastView.swift */,
-				4141398E2A1FA252005418A1 /* PaddingLabel.swift */,
 				41BCFD442A38C099001D3E5F /* Alertable.swift */,
 				413ABEE72A39BBA500EA1010 /* Toastable.swift */,
+				41A3DDF02A593ED4004CFA2F /* AlertViewController.swift */,
+				41A3DDEA2A58428F004CFA2F /* ToastView.swift */,
+				4141398E2A1FA252005418A1 /* PaddingLabel.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1207,6 +1210,7 @@
 				C45BF3AC2A1EF64300CEDE74 /* RecentQueryButton.swift in Sources */,
 				C45BF3972A1D0ADF00CEDE74 /* UserDefaultKey.swift in Sources */,
 				C47F02222A38633500F48884 /* MyPageViewController.swift in Sources */,
+				41A3DDF12A593ED4004CFA2F /* AlertViewController.swift in Sources */,
 				C434A4DC2A19CA6F00C63526 /* SearchingMusicTableViewCell.swift in Sources */,
 				18D671F62A35C5D4003B1A71 /* UIImage+Resizing.swift in Sources */,
 				C434A4D02A17981C00C63526 /* DefaultSearchingMusicRepository.swift in Sources */,

--- a/StreetDrop/StreetDrop/Presentation/CommunityView/View/CommunityViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/View/CommunityViewController.swift
@@ -613,7 +613,13 @@ private extension CommunityViewController {
 
 private extension CommunityViewController {
     func generateGenreLabels(genres: [String]) -> [PaddingLabel] {
+        var genres = genres
         var labels: [PaddingLabel] = []
+
+        if genres.count > 3 {
+            genres = Array(genres[0..<3])
+        }
+
         genres.forEach { genreTitle in
             let label = PaddingLabel(padding: UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12))
             label.text = genreTitle

--- a/StreetDrop/StreetDrop/Presentation/MusicDropView/View/MusicDropViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/MusicDropView/View/MusicDropViewController.swift
@@ -11,7 +11,7 @@ import RxCocoa
 import RxSwift
 import SnapKit
 
-class MusicDropViewController: UIViewController, Toastable {
+class MusicDropViewController: UIViewController, Toastable, Alertable {
 
     enum Constant {
         static let textDefault = " "
@@ -312,7 +312,18 @@ private extension MusicDropViewController {
 
         cancelButton.rx.tap
             .bind { [weak self] in
-                self?.navigationController?.popToRootViewController(animated: true)
+                let dismissAction = UIAction {_ in
+                    self?.navigationController?.dismiss(animated: true)
+                    self?.navigationController?.popToRootViewController(animated: true)
+                }
+
+                self?.showAlert(
+                    state: .gray,
+                    title: "정말 나가시겠어요? 🥺",
+                    subText: "음악과 코멘트 내역은\n자동으로 저장되지 않아요.",
+                    confirmButtonTitle: "나가기",
+                    confirmButtonAction: dismissAction
+                )
             }
             .disposed(by: disposeBag)
     }

--- a/StreetDrop/StreetDrop/Presentation/Utils/AlertViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/Utils/AlertViewController.swift
@@ -1,0 +1,170 @@
+//
+//  AlertViewController.swift
+//  StreetDrop
+//
+//  Created by 맹선아 on 2023/07/08.
+//
+
+import UIKit
+
+import SnapKit
+import RxSwift
+
+final class AlertViewController: UIViewController {
+
+    enum State {
+        case gray
+        case primary
+
+        var secondButtonColor: UIColor {
+            switch self {
+            case .gray:
+                return .gray200
+            case .primary:
+                return .primary500
+            }
+        }
+    }
+
+    private let disposeBag: DisposeBag = DisposeBag()
+
+    init(
+        state: State,
+        title: String,
+        subText: String,
+        confirmButtonTitle: String,
+        confirmButtonAction: UIAction
+    ) {
+        super.init(nibName: nil, bundle: nil)
+        self.mainTitleLabel.text = title
+        self.subTextLabel.text = subText
+        self.confirmButton.backgroundColor = state.secondButtonColor
+        self.confirmButton.setTitle(confirmButtonTitle, for: .normal)
+        self.addConfirmButtonAction(confirmButtonAction)
+        configureUI()
+        bindCancelButtonAction()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI
+
+    private lazy var containerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray700
+        view.layer.cornerRadius = 12
+        view.clipsToBounds = true
+
+        return view
+    }()
+
+    private lazy var containerStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 4
+
+        return stackView
+    }()
+
+    private lazy var mainTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = " "
+        label.textColor = .white
+        label.font = .pretendard(size: 16, weightName: .bold)
+        label.setLineHeight(lineHeight: 24)
+        label.textAlignment = .center
+        label.numberOfLines = 1
+
+        return label
+    }()
+
+    private lazy var subTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = " "
+        label.textColor = .gray300
+        label.font = .pretendard(size: 14, weightName: .medium)
+        label.setLineHeight(lineHeight: 20)
+        label.textAlignment = .center
+        label.numberOfLines = 2
+
+        return label
+    }()
+
+    private lazy var cancelButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("취소", for: .normal)
+        button.setTitleColor(.gray100, for: .normal)
+        button.titleLabel?.font = .pretendard(size: 16, weightName: .medium)
+        button.backgroundColor = .gray500
+        button.layer.cornerRadius = 8
+        button.clipsToBounds = true
+
+        return button
+    }()
+
+    private lazy var confirmButton: UIButton = {
+        let button = UIButton()
+        button.setTitleColor(.gray900, for: .normal)
+        button.titleLabel?.font = .pretendard(size: 16, weightName: .medium)
+        button.layer.cornerRadius = 8
+        button.clipsToBounds = true
+
+        return button
+    }()
+
+    private lazy var buttonStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        stackView.distribution = .fillEqually
+
+        return stackView
+    }()
+}
+
+private extension AlertViewController {
+    func configureUI() {
+        self.view.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.55)
+
+        [cancelButton, confirmButton].forEach {
+            buttonStackView.addArrangedSubview($0)
+        }
+
+        [mainTitleLabel, subTextLabel, buttonStackView].forEach {
+            containerStackView.addArrangedSubview($0)
+        }
+
+        containerView.addSubview(containerStackView)
+        self.view.addSubview(containerView)
+
+        containerStackView.setCustomSpacing(20, after: subTextLabel)
+
+        containerView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(48)
+            $0.centerY.equalToSuperview()
+        }
+
+        containerStackView.snp.makeConstraints {
+            $0.leading.top.trailing.bottom.equalToSuperview().inset(20)
+        }
+
+        buttonStackView.snp.makeConstraints {
+            $0.height.equalTo(44)
+        }
+    }
+
+    func bindCancelButtonAction() {
+        cancelButton.rx.tap
+            .subscribe(onNext: {
+                self.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func addConfirmButtonAction(_ action: UIAction) {
+        confirmButton.addAction(action, for: .touchUpInside)
+    }
+}

--- a/StreetDrop/StreetDrop/Presentation/Utils/Alertable.swift
+++ b/StreetDrop/StreetDrop/Presentation/Utils/Alertable.swift
@@ -30,4 +30,25 @@ extension Alertable where Self: UIViewController {
         requestLocationServiceAlert.addAction(cancel)
         present(requestLocationServiceAlert, animated: true)
     }
+
+    func showAlert(
+        state: AlertViewController.State,
+        title: String,
+        subText: String,
+        confirmButtonTitle: String,
+        confirmButtonAction: UIAction
+    ){
+        let alertViewController = AlertViewController(
+            state: state,
+            title: title,
+            subText: subText,
+            confirmButtonTitle: confirmButtonTitle,
+            confirmButtonAction: confirmButtonAction
+        )
+
+        alertViewController.modalPresentationStyle = .overFullScreen
+        alertViewController.modalTransitionStyle = .crossDissolve
+
+        self.navigationController?.present(alertViewController, animated: true)
+    }
 }


### PR DESCRIPTION
## 📌 배경

close #181 
open #

## 내용
<img width="232" alt="스크린샷 2023-07-09 오후 2 35 29" src="https://github.com/depromeet/street-drop-iOS/assets/107384230/00b262c2-3a34-4496-901f-5c8de14c4e77">

- 알럿을 커스텀했습니다.
- 사용하기쉽게 `Alertable`프토토콜에 POP로구현했습니다 (필요시, 아래 사용법을 참고해주세요!)

### ✅ 사용방법

1. `Alert`을 사용할 `veiwController`에서 `Alertable` 채택

<img width="425" alt="스크린샷 2023-07-09 오후 2 35 13" src="https://github.com/depromeet/street-drop-iOS/assets/107384230/e596e8e8-f40f-414c-91a0-3e7e31f8d971">

2. `showAlert( state: , title: , subText: , confirmButtonTitle: , confirmButtonAction: )` 메서드 호출해서 사용

- 파라미터 설명
    - `state`: 첨부스샷의 확인버튼 스타일 -> 왼쪽: .primary /  오른쪽 .gray
    - `title`: 메인 타이틀 
    - `subText`: 서브 타이틀 ( 최대 두 줄 ) 
    - `confirmButtonTitle`: 오른쪽 버튼 네임
    - `confirmButtonAction`: 오른쪽 버튼 액션
    ( 왼쪽 버튼 취소액션은 알럿을 닫는걸로 고정되어있습니다)
    
 - 사용예시
 ```swift
let dismissAction = UIAction {_ in
    self?.navigationController?.dismiss(animated: true)
    self?.navigationController?.popToRootViewController(animated: true)
}

self?.showAlert(
    state: .gray,
    title: "정말 나가시겠어요? 🥺",
    subText: "음악과 코멘트 내역은\n자동으로 저장되지 않아요.",
    confirmButtonTitle: "나가기",
    confirmButtonAction: dismissAction
)
 ```
 


## 테스트 방법 (optional)
- 드랍화면 우측 상단 '나가기'버튼 액션 확인하기

## 스크린샷 

![Alert](https://github.com/depromeet/street-drop-iOS/assets/107384230/e74916e1-88be-4a73-8d8c-b4551e8d8203)
