### PR TITLE
🐛줌인/줌아웃 시 카메라 움직이지 않으면 원 반경 크기 변하지 않는 현상 해결

### DIFF
--- a/StreetDrop/StreetDrop/Presentation/MainScene/View/MainViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/MainScene/View/MainViewController.swift
@@ -867,7 +867,7 @@ extension MainViewController: NMFMapViewCameraDelegate {
         self.cameraDidStopEvent.accept((mapView.latitude, mapView.longitude))
     }
     
-    func mapView(_ mapView: NMFMapView, cameraIsChangingByReason reason: Int) {
+    func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
         self.locationOverlay.circleRadius = circleRadius / naverMapView.projection.metersPerPixel()
     }
 }


### PR DESCRIPTION
## 📌 배경

close #220 


## 내용
- 줌인/줌아웃 시 카메라 움직이지 않으면 원 반경 크기 변하지 않는 현상 해결
  - 줌인/줌아웃에 따라 원 크기 바뀌는 모습도 자연스러워짐