### PR TITLE
🐛애플 서버 이미지 URL에 대해 Etag 통한 조건부 Get 통신 제외하고, 로컬에 캐싱된 데이터 사용

### DIFF
--- a/StreetDrop/StreetDrop/Presentation/CommunityView/View/AlbumCollectionViewCell.swift
+++ b/StreetDrop/StreetDrop/Presentation/CommunityView/View/AlbumCollectionViewCell.swift
@@ -47,7 +47,11 @@ final class AlbumCollectionViewCell: UICollectionViewCell {
             return
         }
 
-        self.albumImageView.setImage(with: albumImageURL, disposeBag: disposeBag)
+        self.albumImageView.setImage(
+            with: albumImageURL,
+            isImageFromAppleServer: true,
+            disposeBag: disposeBag
+        )
     }
 
     override func prepareForReuse() {

--- a/StreetDrop/StreetDrop/Presentation/MainScene/View/DroppedMusicWithinAreaCollectionViewCell.swift
+++ b/StreetDrop/StreetDrop/Presentation/MainScene/View/DroppedMusicWithinAreaCollectionViewCell.swift
@@ -36,7 +36,11 @@ final class DroppedMusicWithinAreaCollectionViewCell: UICollectionViewCell {
     func setData(item: MusicWithinAreaEntity) {
         self.musicTitleLabel.text = item.musicTitle
         self.singerNameLabel.text = item.artist
-        self.albumCoverImageView.setImage(with: item.albumImageURL, disposeBag: disposeBag)
+        self.albumCoverImageView.setImage(
+            with: item.albumImageURL,
+            isImageFromAppleServer: true,
+            disposeBag: disposeBag
+        )
         self.commentLabel.text = item.content
     }
     

--- a/StreetDrop/StreetDrop/Presentation/MainScene/View/MainViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/MainScene/View/MainViewController.swift
@@ -803,7 +803,7 @@ private extension MainViewController {
         
         let defaultMusicMarkerImage = UIImage(named: "musicMarker") ?? UIImage()
         poiMarker.iconImage = NMFOverlayImage(image: defaultMusicMarkerImage)
-        UIImage.load(with: item.imageURL)
+        UIImage.load(with: item.imageURL, isImageFromAppleServer: true)
             .subscribe(onNext: { albumImage in
                 self.viewModel.markerAlbumImages[poiID] = albumImage
                 self.drawPOIMarker(poiMarker: poiMarker,poiID: poiID, isActivated: false)

--- a/StreetDrop/StreetDrop/Presentation/MyPage/View/MusicTableViewCell.swift
+++ b/StreetDrop/StreetDrop/Presentation/MyPage/View/MusicTableViewCell.swift
@@ -26,7 +26,11 @@ final class MusicTableViewCell: UITableViewCell {
     }
     
     func setData(item: MyMusic) {
-        self.albumCoverImageView.setImage(with: item.albumImageURL, disposeBag: disposeBag)
+        self.albumCoverImageView.setImage(
+            with: item.albumImageURL,
+            isImageFromAppleServer: true,
+            disposeBag: disposeBag
+        )
         self.musicTitleLabel.text = item.song
         self.singerNameLabel.text = item.singer
         self.commentLabel.text = item.comment

--- a/StreetDrop/StreetDrop/Presentation/MyPage/View/MyPageViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/MyPage/View/MyPageViewController.swift
@@ -577,7 +577,11 @@ private extension MyPageViewController {
         output.levelImageURL
             .bind(onNext: { [weak self] levelImageURL in
                 guard let self = self else { return }
-                self.levelImageView.setImage(with: levelImageURL, disposeBag: self.disposeBag)
+                self.levelImageView.setImage(
+                    with: levelImageURL,
+                    isImageFromAppleServer: false,
+                    disposeBag: self.disposeBag
+                )
             })
             .disposed(by: disposeBag)
         

--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicTableViewCell.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicTableViewCell.swift
@@ -36,7 +36,11 @@ class SearchingMusicTableViewCell: UITableViewCell {
     }
     
     func setData(music: Music) {
-        self.albumImage.setImage(with: music.albumImage, disposeBag: disposeBag)
+        self.albumImage.setImage(
+            with: music.albumImage,
+            isImageFromAppleServer: true,
+            disposeBag: disposeBag
+        )
         self.songNameLabel.text = music.songName
         self.artistNameLabel.text = music.artistName
         self.durationTimeLabel.text = music.durationTime

--- a/StreetDrop/StreetDrop/Util/Extensions/UIImage+loadURLImage.swift
+++ b/StreetDrop/StreetDrop/Util/Extensions/UIImage+loadURLImage.swift
@@ -12,10 +12,15 @@ import RxSwift
 extension UIImage {
     static func load(
         with url: String,
-        isUsingDiskCache: Bool = false
+        isUsingDiskCache: Bool = false,
+        isImageFromAppleServer: Bool
     ) -> Observable<UIImage?> {
-        return ImageCacheService.shared.setImage(url, isUsingDiskCache: isUsingDiskCache)
-            .observe(on: MainScheduler.instance)
-            .map { return UIImage(data: $0)}
+        return ImageCacheService.shared.setImage(
+            url,
+            isUsingDiskCache: isUsingDiskCache,
+            isImageFromAppleServer: isImageFromAppleServer
+        )
+        .observe(on: MainScheduler.instance)
+        .map { return UIImage(data: $0)}
     }
 }

--- a/StreetDrop/StreetDrop/Util/Extensions/UIImageView+ImageCache.swift
+++ b/StreetDrop/StreetDrop/Util/Extensions/UIImageView+ImageCache.swift
@@ -10,12 +10,21 @@ import UIKit
 import RxSwift
 
 extension UIImageView {
-    func setImage(with url: String, isUsingDiskCache: Bool = false, disposeBag: DisposeBag) {
-        ImageCacheService.shared.setImage(url, isUsingDiskCache: isUsingDiskCache)
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] image in
-                self?.image = UIImage(data: image)
-            })
-            .disposed(by: disposeBag)
+    func setImage(
+        with url: String,
+        isUsingDiskCache: Bool = false,
+        isImageFromAppleServer: Bool,
+        disposeBag: DisposeBag
+    ) {
+        ImageCacheService.shared.setImage(
+            url,
+            isUsingDiskCache: isUsingDiskCache,
+            isImageFromAppleServer: isImageFromAppleServer
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(onNext: { [weak self] image in
+            self?.image = UIImage(data: image)
+        })
+        .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## 📌 배경

close #223 

## 내용
- 애플 서버 이미지 URL에 대해 Etag 통한 조건부 Get 통신 제외하고, 로컬에 캐싱된 데이터 사용
- #223 이슈 내용 확인 바람
