### PR TITLE
🐛#261: [앱 리젝 대응] 추천검색어 검색결과까지 나오지 않음

### DIFF
--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/View/SearchingMusicViewController.swift
@@ -161,7 +161,8 @@ private extension SearchingMusicViewController {
             }
             .disposed(by: disposeBag)
         
-        self.recommendMusicSearchCollectionView.queryButtonDidTappedEvent.bind { recentQuery in
+        self.recommendMusicSearchCollectionView.queryButtonDidTappedEvent
+            .bind { recentQuery in
             self.searchTextField.text = recentQuery
             self.tableView.isHidden = false
             self.recentMusicSearchView.isHidden = true
@@ -191,6 +192,7 @@ private extension SearchingMusicViewController {
             searchTextFieldEmptyEvent: searchTextFieldEmptyEvent,
             keyBoardDidPressSearchEventWithKeyword: keyBoardDidPressSearchEventWithKeyword,
             recentQueryDidPressEvent: self.recentMusicSearchScrollView.queryButtonDidTappedEvent,
+            recommendQueryDidPressEvent: self.recommendMusicSearchCollectionView.queryButtonDidTappedEvent,
             tableViewCellDidPressedEvent: selectedTableViewCellEvent
         )
         let output = viewModel.convert(input: input, disposedBag: disposeBag)

--- a/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/ViewModel/SearchingMusicViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/SearchingMusicScene/ViewModel/SearchingMusicViewModel.swift
@@ -28,6 +28,7 @@ final class DefaultSearchingMusicViewModel: SearchingMusicViewModel {
         let searchTextFieldEmptyEvent: Observable<Void>
         let keyBoardDidPressSearchEventWithKeyword: Observable<String>
         let recentQueryDidPressEvent: PublishRelay<String>
+        let recommendQueryDidPressEvent: PublishRelay<String>
         let tableViewCellDidPressedEvent: Observable<Int>
     }
     
@@ -91,6 +92,12 @@ final class DefaultSearchingMusicViewModel: SearchingMusicViewModel {
         input.recentQueryDidPressEvent
             .bind { [weak self] recentQuery in
                 self?.searchMusic(output: output, keyword: recentQuery)
+            }
+            .disposed(by: disposedBag)
+        
+        input.recommendQueryDidPressEvent
+            .bind { [weak self] recommendQuery in
+                self?.searchMusic(output: output, keyword: recommendQuery)
             }
             .disposed(by: disposedBag)
         


### PR DESCRIPTION
## 📌 배경
앱 심사 리젝 대응 
서버에서 내려온 추천검색어를 선택 시 검색결과인 노래 리스트가 나오지 않음

close #261 

## 내용
서버에서 내려온 추천검색어를 선택 시 검색결과인 노래 리스트가 나오지 않음

## 테스트 방법
검색 화면에서 추천검색어를 선택

