### PR TITLE
✨#285: 공지사항 조회기능 추가

### DIFF
--- a/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
+++ b/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
@@ -259,8 +259,19 @@
 		C51230A18096B11C82137084 /* libPods-StreetDrop.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 642A4AE13B198B9F5F5F76E4 /* libPods-StreetDrop.a */; };
 		F48DF73A2C1DD8F500F6DEA1 /* SettingPushNotificationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48DF7392C1DD8F500F6DEA1 /* SettingPushNotificationCell.swift */; };
 		F48DF73C2C1DD91C00F6DEA1 /* SettingMusicSelectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48DF73B2C1DD91C00F6DEA1 /* SettingMusicSelectCell.swift */; };
+		F4AA84D92C1F030F00CADB1A /* NoticeListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA84D82C1F030F00CADB1A /* NoticeListResponseDTO.swift */; };
+		F4AA84DB2C1F106300CADB1A /* NoticeDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA84DA2C1F106300CADB1A /* NoticeDetailViewController.swift */; };
+		F4AA84DD2C1F10FF00CADB1A /* NoticeDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA84DC2C1F10FF00CADB1A /* NoticeDetailViewModel.swift */; };
 		F4AA84DF2C1F3B0200CADB1A /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA84DE2C1F3B0200CADB1A /* Array+Extension.swift */; };
+		F4AA84E12C1F732800CADB1A /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA84E02C1F732800CADB1A /* DateManager.swift */; };
 		F4BDF78F2C1DC57500CC6EE6 /* SettingHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BDF78E2C1DC57500CC6EE6 /* SettingHeaderView.swift */; };
+		F4C996A12C1E15CD00FF7B9A /* NoticeListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C996A02C1E15CC00FF7B9A /* NoticeListViewController.swift */; };
+		F4C996A32C1E1B3400FF7B9A /* NoticeListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C996A22C1E1B3400FF7B9A /* NoticeListCell.swift */; };
+		F4C996A52C1EEC3600FF7B9A /* NoticeListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C996A42C1EEC3600FF7B9A /* NoticeListViewModel.swift */; };
+		F4C996A72C1EEC8600FF7B9A /* NoticeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C996A62C1EEC8600FF7B9A /* NoticeUseCase.swift */; };
+		F4C996AA2C1EEF0B00FF7B9A /* DefaultNoticeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C996A92C1EEF0B00FF7B9A /* DefaultNoticeRepository.swift */; };
+		F4C996AD2C1EEF2500FF7B9A /* NoticeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C996AC2C1EEF2500FF7B9A /* NoticeRepository.swift */; };
+		F4C996AF2C1EF6C100FF7B9A /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C996AE2C1EF6C100FF7B9A /* Notice.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -503,8 +514,19 @@
 		C4E4C6BC2A5AE6F500B1C84A /* MusicApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicApp.swift; sourceTree = "<group>"; };
 		F48DF7392C1DD8F500F6DEA1 /* SettingPushNotificationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingPushNotificationCell.swift; sourceTree = "<group>"; };
 		F48DF73B2C1DD91C00F6DEA1 /* SettingMusicSelectCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingMusicSelectCell.swift; sourceTree = "<group>"; };
+		F4AA84D82C1F030F00CADB1A /* NoticeListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeListResponseDTO.swift; sourceTree = "<group>"; };
+		F4AA84DA2C1F106300CADB1A /* NoticeDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailViewController.swift; sourceTree = "<group>"; };
+		F4AA84DC2C1F10FF00CADB1A /* NoticeDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeDetailViewModel.swift; sourceTree = "<group>"; };
 		F4AA84DE2C1F3B0200CADB1A /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
+		F4AA84E02C1F732800CADB1A /* DateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateManager.swift; sourceTree = "<group>"; };
 		F4BDF78E2C1DC57500CC6EE6 /* SettingHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHeaderView.swift; sourceTree = "<group>"; };
+		F4C996A02C1E15CC00FF7B9A /* NoticeListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeListViewController.swift; sourceTree = "<group>"; };
+		F4C996A22C1E1B3400FF7B9A /* NoticeListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeListCell.swift; sourceTree = "<group>"; };
+		F4C996A42C1EEC3600FF7B9A /* NoticeListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeListViewModel.swift; sourceTree = "<group>"; };
+		F4C996A62C1EEC8600FF7B9A /* NoticeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeUseCase.swift; sourceTree = "<group>"; };
+		F4C996A92C1EEF0B00FF7B9A /* DefaultNoticeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNoticeRepository.swift; sourceTree = "<group>"; };
+		F4C996AC2C1EEF2500FF7B9A /* NoticeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeRepository.swift; sourceTree = "<group>"; };
+		F4C996AE2C1EF6C100FF7B9A /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -812,6 +834,7 @@
 				082F170A2AB6E42800174D98 /* MusicDrop */,
 				6AAFD9AE2BCE567A001A6772 /* FetchingLevelPolicyUseCase.swift */,
 				6AAFD9B02BCE56A6001A6772 /* DefaultFetchingLevelPolicyUseCase.swift */,
+				F4C996A62C1EEC8600FF7B9A /* NoticeUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -983,6 +1006,7 @@
 		18F76FAE2A050110006CF9EF /* DataMapping */ = {
 			isa = PBXGroup;
 			children = (
+				F4AA84D72C1F030300CADB1A /* Notice */,
 				1876F03B2A66E01C0064B887 /* MyLevel */,
 				1876F03A2A66E0170064B887 /* MyLikeList */,
 				1876F0392A66DFD90064B887 /* MyDropList */,
@@ -1076,6 +1100,7 @@
 				6A806F9D2BC7A59F0003649E /* MyLevelProgress.swift */,
 				6AAFD9AC2BCE55A4001A6772 /* LevelPolicy.swift */,
 				C44A54922BBC07AA00354F8F /* PopUpInfomation.swift */,
+				F4C996AE2C1EF6C100FF7B9A /* Notice.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -1093,6 +1118,7 @@
 			isa = PBXGroup;
 			children = (
 				4143452D2A373550003FEE2A /* AddressManager.swift */,
+				F4AA84E02C1F732800CADB1A /* DateManager.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -1346,6 +1372,7 @@
 		C47F02202A385BA700F48884 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				F4C9969D2C1E159600FF7B9A /* Notice */,
 				C47F02252A3863A300F48884 /* View */,
 				C47F02262A38640000F48884 /* ViewModel */,
 			);
@@ -1460,6 +1487,7 @@
 		C4E4C6B02A5ADBF200B1C84A /* Setting */ = {
 			isa = PBXGroup;
 			children = (
+				F4C996AB2C1EEF1A00FF7B9A /* Notice */,
 				C4E4C6B12A5ADC2C00B1C84A /* SettingsRepository.swift */,
 			);
 			path = Setting;
@@ -1468,6 +1496,7 @@
 		C4E4C6B52A5ADC4F00B1C84A /* Setting */ = {
 			isa = PBXGroup;
 			children = (
+				F4C996A82C1EEEE200FF7B9A /* Notice */,
 				C4E4C6B32A5ADC4B00B1C84A /* DefaultSettingsRepository.swift */,
 			);
 			path = Setting;
@@ -1480,6 +1509,58 @@
 				2611E7411DB7C5436A272A27 /* Pods-StreetDrop.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		F4AA84D72C1F030300CADB1A /* Notice */ = {
+			isa = PBXGroup;
+			children = (
+				F4AA84D82C1F030F00CADB1A /* NoticeListResponseDTO.swift */,
+			);
+			path = Notice;
+			sourceTree = "<group>";
+		};
+		F4C9969D2C1E159600FF7B9A /* Notice */ = {
+			isa = PBXGroup;
+			children = (
+				F4C9969F2C1E15AB00FF7B9A /* ViewModel */,
+				F4C9969E2C1E15A700FF7B9A /* View */,
+			);
+			path = Notice;
+			sourceTree = "<group>";
+		};
+		F4C9969E2C1E15A700FF7B9A /* View */ = {
+			isa = PBXGroup;
+			children = (
+				F4C996A22C1E1B3400FF7B9A /* NoticeListCell.swift */,
+				F4C996A02C1E15CC00FF7B9A /* NoticeListViewController.swift */,
+				F4AA84DA2C1F106300CADB1A /* NoticeDetailViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		F4C9969F2C1E15AB00FF7B9A /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				F4C996A42C1EEC3600FF7B9A /* NoticeListViewModel.swift */,
+				F4AA84DC2C1F10FF00CADB1A /* NoticeDetailViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		F4C996A82C1EEEE200FF7B9A /* Notice */ = {
+			isa = PBXGroup;
+			children = (
+				F4C996A92C1EEF0B00FF7B9A /* DefaultNoticeRepository.swift */,
+			);
+			path = Notice;
+			sourceTree = "<group>";
+		};
+		F4C996AB2C1EEF1A00FF7B9A /* Notice */ = {
+			isa = PBXGroup;
+			children = (
+				F4C996AC2C1EEF2500FF7B9A /* NoticeRepository.swift */,
+			);
+			path = Notice;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1721,6 +1802,7 @@
 				C47F022A2A3869DC00F48884 /* SettingSectionType.swift in Sources */,
 				41589ABA2A474B3D0029A2EE /* CommunityGuideDetailView.swift in Sources */,
 				F4BDF78F2C1DC57500CC6EE6 /* SettingHeaderView.swift in Sources */,
+				F4C996A52C1EEC3600FF7B9A /* NoticeListViewModel.swift in Sources */,
 				41F23B4E2A1B6EE80083D2EC /* DropMusicRepository.swift in Sources */,
 				C4685B382B72605500F514C7 /* FetchingUserCircleRadiusUsecase.swift in Sources */,
 				18683FE12A349109005A94AC /* PoiEntity.swift in Sources */,
@@ -1780,6 +1862,7 @@
 				41A3DDF82A5AD222004CFA2F /* DefaultBlockUserRepository.swift in Sources */,
 				C47F02242A38633C00F48884 /* SettingsViewModel.swift in Sources */,
 				C41972342ABDB36600211222 /* FetchingPOIUseCase.swift in Sources */,
+				F4C996A12C1E15CD00FF7B9A /* NoticeListViewController.swift in Sources */,
 				1867C8202A4DDB8C00F8EC48 /* MyPageViewController.swift in Sources */,
 				1816ED432A685865005009FC /* NicknameEditModel.swift in Sources */,
 				C40008EA2A32012B00EA7FA9 /* Music.swift in Sources */,
@@ -1809,6 +1892,7 @@
 				C45BF39E2A1D113200CEDE74 /* UserDefaultsRecentMusicSearches.swift in Sources */,
 				6A1386AB2B4F8A5000E49BB5 /* String+Base64.swift in Sources */,
 				41396D8B2A4EFB2500B69341 /* EditCommentRepository.swift in Sources */,
+				F4AA84E12C1F732800CADB1A /* DateManager.swift in Sources */,
 				1816ED3F2A68064E005009FC /* MyPageViewModel.swift in Sources */,
 				C49EDACE2BBD7EFE0025DB55 /* GradientLabel.swift in Sources */,
 				414345212A35B92A003FEE2A /* ResponseSampleData.swift in Sources */,
@@ -1822,10 +1906,12 @@
 				040685022A01539800377094 /* SceneDelegate.swift in Sources */,
 				6A7D73E62BB2AE34009340E3 /* NSMutableAttributedString+.swift in Sources */,
 				C44A549E2BBC0DC500354F8F /* TipPopUpViewController.swift in Sources */,
+				F4C996A32C1E1B3400FF7B9A /* NoticeListCell.swift in Sources */,
 				C4D16FC92A1B9338008B076F /* UIFont+Extension.swift in Sources */,
 				41A9BEB02A4AF45300F3605C /* ClaimModalViewModel.swift in Sources */,
 				04FB1F322A021C330064B3C8 /* TestError.swift in Sources */,
 				188D2C772A1BA74E0088F49C /* LocationManager.swift in Sources */,
+				F4AA84DD2C1F10FF00CADB1A /* NoticeDetailViewModel.swift in Sources */,
 				6A806F9C2BC7A41E0003649E /* MyLevelProgressResponseDTO.swift in Sources */,
 				4143452E2A373550003FEE2A /* AddressManager.swift in Sources */,
 				08BE57162BD4C887007EA949 /* UILabel+applyGradient.swift in Sources */,
@@ -1844,11 +1930,14 @@
 				04FB1F262A0215BC0064B3C8 /* MainViewModel.swift in Sources */,
 				18D671EF2A35A1CB003B1A71 /* MusicWithinAreaResponseDTO.swift in Sources */,
 				41BCFD452A38C099001D3E5F /* Alertable.swift in Sources */,
+				F4C996A72C1EEC8600FF7B9A /* NoticeUseCase.swift in Sources */,
 				F48DF73C2C1DD91C00F6DEA1 /* SettingMusicSelectCell.swift in Sources */,
 				C47F02282A3864A500F48884 /* SettingElementCell.swift in Sources */,
 				082F171A2AB7454200174D98 /* EditCommentUseCase.swift in Sources */,
 				C41972572ABED40100211222 /* DefaultFetchingMyInfoUseCase.swift in Sources */,
 				C419723A2ABDB50B00211222 /* DefaultFetchingMusicCountUseCase.swift in Sources */,
+				F4C996AD2C1EEF2500FF7B9A /* NoticeRepository.swift in Sources */,
+				F4AA84DB2C1F106300CADB1A /* NoticeDetailViewController.swift in Sources */,
 				C47F02282A3864A500F48884 /* SettingElementCell.swift in Sources */,
 				1876F0472A66EDA20064B887 /* MyPageModel.swift in Sources */,
 				18683FDC2A348B15005A94AC /* DefaultMainRepository.swift in Sources */,
@@ -1861,11 +1950,13 @@
 				41396DA42A51B61000B69341 /* EditCommentViewModel.swift in Sources */,
 				049F50222A122C8A001528CB /* DropMusicRequestDTO+Mapping.swift in Sources */,
 				C49EDACC2BBD75480025DB55 /* CongratulationsLevelUpPopUpViewController.swift in Sources */,
+				F4C996AF2C1EF6C100FF7B9A /* Notice.swift in Sources */,
 				41A9BEB92A4DCA4A00F3605C /* ClaimCommentRepository.swift in Sources */,
 				C45BF3A32A1D179C00CEDE74 /* RecentMusicQueriesStorage.swift in Sources */,
 				041038972A126E7B00BC5532 /* MusicCountByDongResponseDTO+Mapping.swift in Sources */,
 				41396D992A4F04D800B69341 /* UserDefaultsMyInfoStorage.swift in Sources */,
 				C419723E2ABDB5D600211222 /* DefaultFetchingMusicWithinArea.swift in Sources */,
+				F4C996AA2C1EEF0B00FF7B9A /* DefaultNoticeRepository.swift in Sources */,
 				41396D972A4F04CB00B69341 /* MyInfoStorage.swift in Sources */,
 				1824F1372A349F3700A10320 /* MusicCountEntity.swift in Sources */,
 				C4685B3A2B72610600F514C7 /* DefaultFetchingUserCircleRadiusUsecase.swift in Sources */,
@@ -1899,6 +1990,7 @@
 				C42361782B0CE8F800F61E3C /* RecommendMusic.swift in Sources */,
 				6A7D73DF2BB15826009340E3 /* UIView+RoundCorners.swift in Sources */,
 				08B97EA52B44303C00084F66 /* UniviersialLinkKey.swift in Sources */,
+				F4AA84D92C1F030F00CADB1A /* NoticeListResponseDTO.swift in Sources */,
 				C4A445932A5EF265008279C1 /* DefaultFCMRepository.swift in Sources */,
 				41B953682A10E39D00BEC0AB /* SearchedMusicResponseDTO+Mapping.swift in Sources */,
 				C434A4CA2A1796E400C63526 /* SearchingMusicViewController.swift in Sources */,

--- a/StreetDrop/StreetDrop/Data/DataMapping/Notice/NoticeListResponseDTO.swift
+++ b/StreetDrop/StreetDrop/Data/DataMapping/Notice/NoticeListResponseDTO.swift
@@ -25,7 +25,7 @@ struct NoticeDetailDTO: Decodable {
 }
 
 extension NoticeListResponseDTO {
-    func toEntity() -> [NoticeEntity] {
+    var toEntity: [NoticeEntity] {
         data.map {
             .init(
                 announcementId: $0.announcementId,
@@ -37,8 +37,8 @@ extension NoticeListResponseDTO {
 }
 
 extension NoticeDetailDTO {
-    func toEntity() -> NoticeDetailEntity {
-        return .init(
+    var toEntity: NoticeDetailEntity {
+        .init(
             announcementId: announcementId,
             title: title,
             content: content,

--- a/StreetDrop/StreetDrop/Data/DataMapping/Notice/NoticeListResponseDTO.swift
+++ b/StreetDrop/StreetDrop/Data/DataMapping/Notice/NoticeListResponseDTO.swift
@@ -1,0 +1,48 @@
+//
+//  NoticeListResponseDTO.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import Foundation
+
+struct NoticeListResponseDTO: Decodable {
+    let data: [NoticeDTO]
+}
+
+struct NoticeDTO: Decodable {
+    let announcementId: Int
+    let title: String
+    let createdAt: String
+}
+
+struct NoticeDetailDTO: Decodable {
+    let announcementId: Int
+    let title: String
+    let content: String
+    let createdAt: String
+}
+
+extension NoticeListResponseDTO {
+    func toEntity() -> [NoticeEntity] {
+        data.map {
+            .init(
+                announcementId: $0.announcementId,
+                title: $0.title,
+                createdAt: $0.createdAt
+            )
+        }
+    }
+}
+
+extension NoticeDetailDTO {
+    func toEntity() -> NoticeDetailEntity {
+        return .init(
+            announcementId: announcementId,
+            title: title,
+            content: content,
+            createdAt: createdAt
+        )
+    }
+}

--- a/StreetDrop/StreetDrop/Data/Repositories/Protocol/Setting/Notice/NoticeRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/Protocol/Setting/Notice/NoticeRepository.swift
@@ -1,0 +1,16 @@
+//
+//  NoticeRepository.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol NoticeRepository {
+    func fetchNoticeList() -> Single<[NoticeEntity]>
+    func fetchNoticeDetail(id: Int) -> Single<NoticeDetailEntity>
+}
+

--- a/StreetDrop/StreetDrop/Data/Repositories/Setting/Notice/DefaultNoticeRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/Setting/Notice/DefaultNoticeRepository.swift
@@ -24,17 +24,11 @@ final class DefaultNoticeRepository: NoticeRepository {
     
     func fetchNoticeList() -> Single<[NoticeEntity]> {
         networkManager.getNoticeList()
-            .map({ data in
-                let dto = try JSONDecoder().decode(NoticeListResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+            .map(\.toEntity)
     }
     
     func fetchNoticeDetail(id: Int) -> Single<NoticeDetailEntity> {
         networkManager.getNoticeDetail(id: id)
-            .map({ data in
-                let dto = try JSONDecoder().decode(NoticeDetailDTO.self, from: data)
-                return dto.toEntity()
-            })
+            .map(\.toEntity)
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/Setting/Notice/DefaultNoticeRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/Setting/Notice/DefaultNoticeRepository.swift
@@ -1,0 +1,40 @@
+//
+//  DefaultNoticeRepository.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import Foundation
+
+import Moya
+import RxSwift
+
+final class DefaultNoticeRepository: NoticeRepository {
+    private let networkManager: NetworkManager
+    private let disposeBag: DisposeBag = .init()
+    
+    init(
+        networkManager: NetworkManager = NetworkManager(
+            provider: MoyaProvider<NetworkService>()
+        )
+    ) {
+        self.networkManager = networkManager
+    }
+    
+    func fetchNoticeList() -> Single<[NoticeEntity]> {
+        networkManager.getNoticeList()
+            .map({ data in
+                let dto = try JSONDecoder().decode(NoticeListResponseDTO.self, from: data)
+                return dto.toEntity()
+            })
+    }
+    
+    func fetchNoticeDetail(id: Int) -> Single<NoticeDetailEntity> {
+        networkManager.getNoticeDetail(id: id)
+            .map({ data in
+                let dto = try JSONDecoder().decode(NoticeDetailDTO.self, from: data)
+                return dto.toEntity()
+            })
+    }
+}

--- a/StreetDrop/StreetDrop/Domain/Entity/Notice.swift
+++ b/StreetDrop/StreetDrop/Domain/Entity/Notice.swift
@@ -1,0 +1,34 @@
+//
+//  Notice.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import Foundation
+
+struct Notice: Hashable {
+    let announcementId: Int
+    let title: String
+    let createdAt: String?
+}
+
+struct NoticeDetail: Hashable {
+    let announcementId: Int
+    let title: String
+    let content: String
+    let createdAt: String?
+}
+
+struct NoticeEntity {
+    let announcementId: Int
+    let title: String
+    let createdAt: String
+}
+
+struct NoticeDetailEntity {
+    let announcementId: Int
+    let title: String
+    let content: String
+    let createdAt: String
+}

--- a/StreetDrop/StreetDrop/Domain/Entity/Notice.swift
+++ b/StreetDrop/StreetDrop/Domain/Entity/Notice.swift
@@ -8,12 +8,14 @@
 import Foundation
 
 struct Notice: Hashable {
+    let uuid = UUID()
     let announcementId: Int
     let title: String
     let createdAt: String?
 }
 
 struct NoticeDetail: Hashable {
+    let uuid = UUID()
     let announcementId: Int
     let title: String
     let content: String

--- a/StreetDrop/StreetDrop/Domain/UseCase/NoticeUseCase.swift
+++ b/StreetDrop/StreetDrop/Domain/UseCase/NoticeUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  NoticeUseCase.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol NoticeUseCase {
+    func fetchNoticeList() -> Single<[NoticeEntity]>
+    func fetchNoticeDetail(id: Int) -> Single<NoticeDetailEntity>
+}
+
+final class DefaultNoticeUseCase: NoticeUseCase {
+    private let noticeRepository: NoticeRepository
+    
+    init(noticeRepository: NoticeRepository = DefaultNoticeRepository()) {
+        self.noticeRepository = noticeRepository
+    }
+    
+    func fetchNoticeList() -> Single<[NoticeEntity]> {
+        return noticeRepository.fetchNoticeList()
+    }
+    
+    func fetchNoticeDetail(id: Int) -> Single<NoticeDetailEntity> {
+        return noticeRepository.fetchNoticeDetail(id: id)
+    }
+}

--- a/StreetDrop/StreetDrop/Network/NetworkManager.swift
+++ b/StreetDrop/StreetDrop/Network/NetworkManager.swift
@@ -189,4 +189,16 @@ struct NetworkManager {
         .retry(3)
         .map { _ in }
     }
+    
+    func getNoticeList() -> Single<Data> {
+        return provider.rx.request(.getNoticeList)
+        .retry(3)
+        .map { $0.data }
+    }
+    
+    func getNoticeDetail(id: Int) -> Single<Data> {
+        return provider.rx.request(.getNoticeDetail(id: id))
+        .retry(3)
+        .map { $0.data }
+    }
 }

--- a/StreetDrop/StreetDrop/Network/NetworkManager.swift
+++ b/StreetDrop/StreetDrop/Network/NetworkManager.swift
@@ -190,15 +190,15 @@ struct NetworkManager {
         .map { _ in }
     }
     
-    func getNoticeList() -> Single<Data> {
+    func getNoticeList() -> Single<NoticeListResponseDTO> {
         return provider.rx.request(.getNoticeList)
         .retry(3)
-        .map { $0.data }
+        .map(NoticeListResponseDTO.self)
     }
     
-    func getNoticeDetail(id: Int) -> Single<Data> {
+    func getNoticeDetail(id: Int) -> Single<NoticeDetailDTO> {
         return provider.rx.request(.getNoticeDetail(id: id))
         .retry(3)
-        .map { $0.data }
+        .map(NoticeDetailDTO.self)
     }
 }

--- a/StreetDrop/StreetDrop/Network/NetworkService.swift
+++ b/StreetDrop/StreetDrop/Network/NetworkService.swift
@@ -37,6 +37,8 @@ enum NetworkService {
     case userCircleRadius
     case getPopUpInfomation
     case postPopUpUserReading(requestDTO: PopUpUserReadingRequestDTO)
+    case getNoticeList
+    case getNoticeDetail(id: Int)
 }
 
 extension NetworkService: TargetType {
@@ -110,6 +112,10 @@ extension NetworkService: TargetType {
             return "/pop-up"
         case .postPopUpUserReading:
             return "/pop-up/read"
+        case .getNoticeList:
+            return "/announcements"
+        case .getNoticeDetail(let id):
+            return "/announcements/\(id)"
         }
     }
     
@@ -130,7 +136,9 @@ extension NetworkService: TargetType {
                 .myLevelProgress,
                 .levelPolicy,
                 .userCircleRadius,
-                .getPopUpInfomation:
+                .getPopUpInfomation,
+                .getNoticeList,
+                .getNoticeDetail:
             return .get
         case .dropMusic,
                 .postLikeUp,
@@ -149,7 +157,8 @@ extension NetworkService: TargetType {
     
     var task: Moya.Task {
         switch self {
-        case .getMyInfo, .myDropList, .myLikeList, .myLevel, .myLevelProgress, .levelPolicy, .recommendMusic, .userCircleRadius, .getPopUpInfomation:
+        case .getMyInfo, .myDropList, .myLikeList, .myLevel, .myLevelProgress, .levelPolicy, .recommendMusic, .userCircleRadius, .getPopUpInfomation,
+            .getNoticeList, .getNoticeDetail:
             return .requestPlain
         case .searchMusic(let keyword):
             return .requestParameters(

--- a/StreetDrop/StreetDrop/Presentation/Settings/Notice/View/NoticeDetailViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/Settings/Notice/View/NoticeDetailViewController.swift
@@ -1,0 +1,237 @@
+//
+//  NoticeDetailViewController.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import UIKit
+
+import RxRelay
+import RxSwift
+import SnapKit
+
+final class NoticeDetailViewController: UIViewController, Toastable {
+    private let disposeBag = DisposeBag()
+    private let viewModel: DefaultNoticeDetailViewModel
+    private let viewDidLoadEvent = PublishRelay<Void>()
+    
+    private lazy var navigationBar: UIView = {
+        let view = UIView()
+        return view
+    }()
+    
+    private lazy var backButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setImage(UIImage(named: "backButton"), for: .normal)
+        return button
+    }()
+    
+    private lazy var navigationTitle: UILabel = {
+        let label: UILabel = UILabel()
+        label.text = "공지사항"
+        label.textColor = UIColor(red: 0.844, green: 0.881, blue: 0.933, alpha: 1)
+        label.font = .pretendard(size: 16, weightName: .bold)
+        label.setLineHeight(lineHeight: 20)
+        return label
+    }()
+    
+    private lazy var titleView: UIView = {
+        let view: UIView = UIView()
+        return view
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.textColor = .white
+        label.font = .pretendard(size: 20, weightName: .bold)
+        label.setLineHeight(lineHeight: 28)
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    private lazy var createdAtLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.textColor = .gray200
+        label.font = .pretendard(size: 12, weightName: .regular)
+        label.setLineHeight(lineHeight: 16)
+        return label
+    }()
+    
+    private lazy var markdownTextView: UITextView = {
+        let textView: UITextView = UITextView()
+        textView.backgroundColor = .clear
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.font = .pretendard(size: 14, weightName: .regular)
+        textView.textColor = .white
+        return textView
+    }()
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    init(viewModel: DefaultNoticeDetailViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        
+        bindAction()
+        bindViewModel()
+        
+        viewDidLoadEvent.accept(Void())
+    }
+    
+    private func configureTitleView() {
+        let titleStackView = UIStackView()
+        titleStackView.axis = .vertical
+        titleStackView.distribution = .fill
+        titleStackView.alignment = .leading
+        titleStackView.spacing = 8
+        
+        let bottomLineView = UIView()
+        bottomLineView.backgroundColor = .gray700
+        
+        [
+            titleStackView,
+            bottomLineView
+        ].forEach {
+            self.titleView.addSubview($0)
+        }
+        
+        titleStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(24)
+            $0.leading.trailing.equalToSuperview().inset(24)
+        }
+        
+        bottomLineView.snp.makeConstraints {
+            $0.height.equalTo(1)
+            $0.top.equalTo(titleStackView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview()
+        }
+        
+        [
+            self.titleLabel,
+            self.createdAtLabel
+        ].forEach {
+            titleStackView.addArrangedSubview($0)
+        }
+    }
+    
+    private func configureUI() {
+        self.view.backgroundColor = UIColor.gray900
+        
+        [
+            self.backButton,
+            self.navigationTitle
+        ].forEach {
+            self.navigationBar.addSubview($0)
+        }
+        
+        self.backButton.snp.makeConstraints {
+            $0.width.height.equalTo(32)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        self.navigationTitle.snp.makeConstraints {
+            $0.centerX.centerY.equalToSuperview()
+        }
+        
+        let scrollView = UIScrollView()
+        scrollView.alwaysBounceVertical = true
+        
+        [
+            self.navigationBar,
+            scrollView
+        ].forEach {
+            self.view.addSubview($0)
+        }
+        
+        self.navigationBar.snp.makeConstraints {
+            $0.height.equalTo(60)
+            $0.top.equalTo(self.view.safeAreaLayoutGuide)
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
+        }
+        
+        scrollView.snp.makeConstraints { make in
+            make.top.equalTo(self.navigationBar.snp.bottom)
+            make.width.equalToSuperview()
+            make.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
+            
+            /// 34(safeArea bottom inset) + 30 = 64
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(30)
+        }
+        
+        let containerView = UIView()
+        scrollView.addSubview(containerView)
+        containerView.snp.makeConstraints { make in
+            make.edges.width.equalTo(scrollView)
+            make.height.equalTo(scrollView).priority(.low)
+        }
+        
+        configureTitleView()
+        
+        [
+            self.titleView,
+            self.markdownTextView
+        ].forEach {
+            containerView.addSubview($0)
+        }
+        
+        self.titleView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+        }
+        
+        self.markdownTextView.snp.makeConstraints {
+            $0.top.equalTo(self.titleView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview()
+        }
+    }
+}
+
+extension NoticeDetailViewController {
+    func bindAction() {
+        Observable.merge(
+            self.backButton.rx.tap.asObservable()
+        )
+        .bind { _ in
+            self.navigationController?.popViewController(animated: true)
+        }
+        .disposed(by: disposeBag)
+    }
+    
+    func bindViewModel() {
+        let input = DefaultNoticeDetailViewModel.Input(
+            viewDidLoadEvent: viewDidLoadEvent.asObservable()
+        )
+        
+        let output = viewModel.convert(
+            input: input,
+            disposedBag: disposeBag
+        )
+        
+        output.noticeDetail
+            .bind { [weak self] noticeDetail in
+                self?.displayNoticeDetail(noticeDetail)
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func displayNoticeDetail(_ noticeDetail: NoticeDetail) {
+        titleLabel.text = noticeDetail.title
+        createdAtLabel.text = noticeDetail.createdAt
+        
+        // TODO: jihye - markdown -> html?
+        markdownTextView.text = noticeDetail.content
+    }
+}

--- a/StreetDrop/StreetDrop/Presentation/Settings/Notice/View/NoticeListCell.swift
+++ b/StreetDrop/StreetDrop/Presentation/Settings/Notice/View/NoticeListCell.swift
@@ -1,0 +1,92 @@
+//
+//  NoticeListCell.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 15/06/2024.
+//
+
+import UIKit
+
+import SnapKit
+
+class NoticeListCell: UICollectionViewCell {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been impl")
+    }
+    
+    private lazy var titleLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.font = .pretendard(size: 16, weightName: .medium)
+        label.setLineHeight(lineHeight: 24)
+        label.textColor = .white
+        label.numberOfLines = 2
+        
+        return label
+    }()
+    
+    private lazy var createdAtLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.font = .pretendard(size: 12, weightName: .regular)
+        label.setLineHeight(lineHeight: 16)
+        label.textColor = .gray200
+        label.numberOfLines = 1
+        
+        return label
+    }()
+    
+    private lazy var bottomLineView: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = .gray700
+        
+        return view
+    }()
+    
+    func configure(with item: Notice) {
+        titleLabel.text = item.title
+        createdAtLabel.text = item.createdAt
+    }
+}
+
+private extension NoticeListCell {
+    func configureUI() {
+        self.backgroundColor = .gray900
+        
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .leading
+        stackView.spacing = 8
+        
+        [
+            stackView,
+            self.bottomLineView
+        ].forEach {
+            self.addSubview($0)
+        }
+        
+        [
+            self.titleLabel,
+            self.createdAtLabel,
+        ].forEach {
+            stackView.addArrangedSubview($0)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(24)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        self.bottomLineView.snp.makeConstraints {
+            $0.height.equalTo(1)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.top.equalTo(stackView.snp.bottom).offset(20)
+        }
+    }
+}

--- a/StreetDrop/StreetDrop/Presentation/Settings/Notice/View/NoticeListViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/Settings/Notice/View/NoticeListViewController.swift
@@ -188,11 +188,10 @@ extension NoticeListViewController {
             disposedBag: disposeBag
         )
         
-        output.noticeList
-            .bind { [weak self] noticeList in
-                self?.displayNoticeList(noticeList)
-            }
-            .disposed(by: disposeBag)
+        output.noticeList.bind(with: self) { owner, noticeList in
+            owner.displayNoticeList(noticeList)
+        }
+        .disposed(by: disposeBag)
     }
     
     private func displayNoticeList(_ noticeList: [Notice]) {

--- a/StreetDrop/StreetDrop/Presentation/Settings/Notice/View/NoticeListViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/Settings/Notice/View/NoticeListViewController.swift
@@ -1,0 +1,204 @@
+//
+//  NoticeListViewController.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 15/06/2024.
+//
+
+import UIKit
+
+import RxRelay
+import RxSwift
+import SnapKit
+
+final class NoticeListViewController: UIViewController, Toastable {
+    private let disposeBag = DisposeBag()
+    private let viewModel: DefaultNoticeListViewModel
+    private let viewDidLoadEvent = PublishRelay<Void>()
+    
+    private var collectionView: UICollectionView!
+    private var dataSource: UICollectionViewDiffableDataSource<Int, Notice>!
+    
+    private lazy var navigationBar: UIView = {
+        let view = UIView()
+        return view
+    }()
+    
+    private lazy var backButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setImage(UIImage(named: "backButton"), for: .normal)
+        return button
+    }()
+    
+    private lazy var navigationTitle: UILabel = {
+        let label: UILabel = UILabel()
+        label.text = "공지사항"
+        label.textColor = UIColor(red: 0.844, green: 0.881, blue: 0.933, alpha: 1)
+        label.font = .pretendard(size: 16, weightName: .bold)
+        label.setLineHeight(lineHeight: 20)
+        return label
+    }()
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    init(viewModel: DefaultNoticeListViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        configureCollectionView()
+        configureDataSource()
+        
+        bindAction()
+        bindViewModel()
+        
+        viewDidLoadEvent.accept(Void())
+    }
+    
+    private func configureUI() {
+        self.view.backgroundColor = UIColor.gray900
+        
+        [
+            self.backButton,
+            self.navigationTitle
+        ].forEach {
+            self.navigationBar.addSubview($0)
+        }
+        
+        [
+            self.navigationBar
+        ].forEach {
+            self.view.addSubview($0)
+        }
+        
+        self.navigationBar.snp.makeConstraints {
+            $0.height.equalTo(60)
+            $0.top.equalTo(self.view.safeAreaLayoutGuide)
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
+        }
+        
+        self.backButton.snp.makeConstraints {
+            $0.width.height.equalTo(32)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        self.navigationTitle.snp.makeConstraints {
+            $0.centerX.centerY.equalToSuperview()
+        }
+    }
+}
+
+// MARK: CollectionView
+
+extension NoticeListViewController: UICollectionViewDelegate {
+    private func configureCollectionView() {
+        collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
+        collectionView.backgroundColor = .clear
+        collectionView.delegate = self
+        view.addSubview(collectionView)
+        
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(navigationBar.snp.bottom)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+    
+    private func createLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment in
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .estimated(93)
+            )
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            
+            let groupSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .estimated(93)
+            )
+            let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+            
+            let section = NSCollectionLayoutSection(group: group)
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: 0,
+                leading: 24,
+                bottom: 24,
+                trailing: 24
+            )
+            
+            return section
+        }
+    }
+    
+    private func configureDataSource() {
+        typealias CellRegistration = UICollectionView.CellRegistration<NoticeListCell, Notice>
+        let cellRegistration = CellRegistration { cell, indexPath, item in
+            cell.configure(with: item)
+        }
+        
+        dataSource = UICollectionViewDiffableDataSource<Int, Notice>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, item -> UICollectionViewCell? in
+            collectionView.dequeueConfiguredReusableCell(
+                using: cellRegistration,
+                for: indexPath,
+                item: item
+            )
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let notice = self.dataSource.itemIdentifier(for: indexPath) else { return }
+        
+        let noticeDetailViewController = NoticeDetailViewController(
+            viewModel: .init(noticeId: notice.announcementId)
+        )
+        self.navigationController?.pushViewController(
+            noticeDetailViewController,
+            animated: true
+        )
+    }
+}
+
+extension NoticeListViewController {
+    func bindAction() {
+        Observable.merge(
+            self.backButton.rx.tap.asObservable()
+        )
+        .bind { _ in
+            self.navigationController?.popViewController(animated: true)
+        }
+        .disposed(by: disposeBag)
+    }
+    
+    func bindViewModel() {
+        let input = DefaultNoticeListViewModel.Input(
+            viewDidLoadEvent: viewDidLoadEvent.asObservable()
+        )
+        
+        let output = viewModel.convert(
+            input: input,
+            disposedBag: disposeBag
+        )
+        
+        output.noticeList
+            .bind { [weak self] noticeList in
+                self?.displayNoticeList(noticeList)
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func displayNoticeList(_ noticeList: [Notice]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Int, Notice>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(noticeList, toSection: 0)
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+}

--- a/StreetDrop/StreetDrop/Presentation/Settings/Notice/ViewModel/NoticeDetailViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/Settings/Notice/ViewModel/NoticeDetailViewModel.swift
@@ -1,0 +1,72 @@
+//
+//  NoticeDetailViewModel.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import Foundation
+
+import RxRelay
+import RxSwift
+
+protocol NoticeDetailViewModel: ViewModel { }
+
+final class DefaultNoticeDetailViewModel: NoticeDetailViewModel {
+    private let noticeId: Int
+    private let useCase: NoticeUseCase
+    private let dateManager: DateManager
+    
+    init(
+        noticeId: Int,
+        useCase: NoticeUseCase = DefaultNoticeUseCase(),
+        dateManager: DateManager = DefaultDateManager()
+    ) {
+        self.noticeId = noticeId
+        self.useCase = useCase
+        self.dateManager = dateManager
+    }
+    
+    struct Input {
+        let viewDidLoadEvent: Observable<Void>
+    }
+    
+    struct Output {
+        let noticeDetail: PublishRelay<NoticeDetail> = .init()
+    }
+    
+    func convert(input: Input, disposedBag: DisposeBag) -> Output {
+        let output = Output()
+        
+        input.viewDidLoadEvent
+            .bind { [weak self] in
+                guard let self else { return }
+                self.fetchNoticeDetail(id: self.noticeId, output: output, disposeBag: disposedBag)
+            }
+            .disposed(by: disposedBag)
+        
+        return output
+    }
+}
+
+private extension DefaultNoticeDetailViewModel {
+    func fetchNoticeDetail(id: Int, output: Output, disposeBag: DisposeBag) {
+        self.useCase.fetchNoticeDetail(id: id)
+            .subscribe { [weak self] noticeDetail in
+                guard let self else { return }
+                output.noticeDetail.accept(self.convertToNoticeDetail(noticeDetail))
+            } onFailure: { error in
+                // TODO: jihye - 에러처리
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func convertToNoticeDetail(_ noticeDetail: NoticeDetailEntity) -> NoticeDetail {
+        .init(
+            announcementId: noticeDetail.announcementId,
+            title: noticeDetail.title,
+            content: noticeDetail.content,
+            createdAt: dateManager.convertToformattedString(noticeDetail.createdAt)
+        )
+    }
+}

--- a/StreetDrop/StreetDrop/Presentation/Settings/Notice/ViewModel/NoticeListViewModel.swift
+++ b/StreetDrop/StreetDrop/Presentation/Settings/Notice/ViewModel/NoticeListViewModel.swift
@@ -1,0 +1,69 @@
+//
+//  NoticeListViewModel.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import Foundation
+
+import RxRelay
+import RxSwift
+
+protocol NoticeListViewModel: ViewModel { }
+
+final class DefaultNoticeListViewModel: NoticeListViewModel {
+    private let useCase: NoticeUseCase
+    private let dateManager: DateManager
+    
+    init(
+        useCase: NoticeUseCase = DefaultNoticeUseCase(),
+        dateManager: DateManager = DefaultDateManager()
+    ) {
+        self.useCase = useCase
+        self.dateManager = dateManager
+    }
+    
+    struct Input {
+        let viewDidLoadEvent: Observable<Void>
+    }
+    
+    struct Output {
+        let noticeList: PublishRelay<[Notice]> = .init()
+        let noticeListFailAlert: PublishRelay<String> = .init()
+    }
+    
+    func convert(input: Input, disposedBag: DisposeBag) -> Output {
+        let output = Output()
+        
+        input.viewDidLoadEvent
+            .bind { [weak self] in
+                self?.fetchNoticeList(output: output, disposeBag: disposedBag)
+            }
+            .disposed(by: disposedBag)
+        
+        return output
+    }
+}
+
+private extension DefaultNoticeListViewModel {
+    func fetchNoticeList(output: Output, disposeBag: DisposeBag) {
+        self.useCase.fetchNoticeList()
+            .subscribe { [weak self] noticeList in
+                guard let self else { return }
+                output.noticeList.accept(noticeList.map { self.convertToNotice($0) })
+            } onFailure: { error in
+                // TODO: jihye - 에러처리
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func convertToNotice(_ notice: NoticeEntity) -> Notice {
+        .init(
+            announcementId: notice.announcementId,
+            title: notice.title,
+            createdAt: dateManager.convertToformattedString(notice.createdAt)
+        )
+    }
+}
+

--- a/StreetDrop/StreetDrop/Presentation/Settings/View/SettingsViewController.swift
+++ b/StreetDrop/StreetDrop/Presentation/Settings/View/SettingsViewController.swift
@@ -239,13 +239,11 @@ extension SettingsViewController: UICollectionViewDelegate {
             UIApplication.shared.open(url)
             
         case .notice(_):
-            // TODO: jihye
-//            let noticeListViewController = NoticeListViewController(viewModel: .init())
-//            self.navigationController?.pushViewController(
-//                noticeListViewController,
-//                animated: true
-//            )
-            return
+            let noticeListViewController = NoticeListViewController(viewModel: .init())
+            self.navigationController?.pushViewController(
+                noticeListViewController,
+                animated: true
+            )
             
         default:
             return

--- a/StreetDrop/StreetDrop/Util/Constant/SettingSectionType.swift
+++ b/StreetDrop/StreetDrop/Util/Constant/SettingSectionType.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 struct SettingSectionType: Hashable {
+    let uuid = UUID()
     let section: SettingSection
     let items: [SettingItem]
 }

--- a/StreetDrop/StreetDrop/Util/Service/DateManager.swift
+++ b/StreetDrop/StreetDrop/Util/Service/DateManager.swift
@@ -1,0 +1,22 @@
+//
+//  DateManager.swift
+//  StreetDrop
+//
+//  Created by jihye kim on 16/06/2024.
+//
+
+import Foundation
+
+protocol DateManager {
+    func convertToformattedString(_ dateString: String) -> String?
+}
+
+final class DefaultDateManager: DateManager {
+    func convertToformattedString(_ dateString: String) -> String? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+        guard let date = dateFormatter.date(from: dateString) else { return nil }
+        dateFormatter.dateFormat = "yyyy. MM. dd"
+        return dateFormatter.string(from: date)
+    }
+}


### PR DESCRIPTION
## 📌 공지사항 리스트/디테일 화면 추가

## 내용
- 설정화면 > 공지사항 메뉴 클릭 시 공지사항 리스트 화면
- 공지사항 리스트에서 특정 공지사항 누르면 디테일을 볼 수 있는 화면으로 이동
- 마크다운은 논의가 필요해서 추후 PR에서 수정예정입니다

## 스크린샷
| NoticeList | NoticeDetail |
| :--- | :---: |
| <img width="238" alt="image" src="https://github.com/depromeet/street-drop-iOS/assets/171426798/577d83e5-9f86-4948-86c2-0dadb6fd3fa3"> | <img width="237" alt="image" src="https://github.com/depromeet/street-drop-iOS/assets/171426798/3741d7cf-f83b-4fe1-a0ac-dbc07f30bf5b"> |


