### PR TITLE
♻️ Moya 네트워크 통신 로직 리팩토링

### DIFF
--- a/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
+++ b/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		C4E4C6B82A5ADFDB00B1C84A /* SettingsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E4C6B72A5ADFDB00B1C84A /* SettingsUseCase.swift */; };
 		C4E4C6BA2A5AE40900B1C84A /* UserDefaultsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E4C6B92A5AE40900B1C84A /* UserDefaultsError.swift */; };
 		C4E4C6BD2A5AE6F500B1C84A /* MusicApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E4C6BC2A5AE6F500B1C84A /* MusicApp.swift */; };
+		C4E68C852C2A996000742464 /* AsynchronousError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E68C842C2A996000742464 /* AsynchronousError.swift */; };
 		C51230A18096B11C82137084 /* libPods-StreetDrop.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 642A4AE13B198B9F5F5F76E4 /* libPods-StreetDrop.a */; };
 		F48DF73A2C1DD8F500F6DEA1 /* SettingPushNotificationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48DF7392C1DD8F500F6DEA1 /* SettingPushNotificationCell.swift */; };
 		F48DF73C2C1DD91C00F6DEA1 /* SettingMusicSelectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48DF73B2C1DD91C00F6DEA1 /* SettingMusicSelectCell.swift */; };
@@ -512,6 +513,7 @@
 		C4E4C6B72A5ADFDB00B1C84A /* SettingsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUseCase.swift; sourceTree = "<group>"; };
 		C4E4C6B92A5AE40900B1C84A /* UserDefaultsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsError.swift; sourceTree = "<group>"; };
 		C4E4C6BC2A5AE6F500B1C84A /* MusicApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicApp.swift; sourceTree = "<group>"; };
+		C4E68C842C2A996000742464 /* AsynchronousError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsynchronousError.swift; sourceTree = "<group>"; };
 		F48DF7392C1DD8F500F6DEA1 /* SettingPushNotificationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingPushNotificationCell.swift; sourceTree = "<group>"; };
 		F48DF73B2C1DD91C00F6DEA1 /* SettingMusicSelectCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingMusicSelectCell.swift; sourceTree = "<group>"; };
 		F4AA84D82C1F030F00CADB1A /* NoticeListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeListResponseDTO.swift; sourceTree = "<group>"; };
@@ -776,6 +778,7 @@
 				C45A4CAF2A3710AC00EE9C36 /* ImageCacheError.swift */,
 				C4E4C6B92A5AE40900B1C84A /* UserDefaultsError.swift */,
 				C41972312ABDAEF200211222 /* MyInfoError.swift */,
+				C4E68C842C2A996000742464 /* AsynchronousError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -1793,6 +1796,7 @@
 			files = (
 				C41972362ABDB3C000211222 /* DefaultFetchingPOIUseCase.swift in Sources */,
 				C41972552ABED3EC00211222 /* FetchingMyInfoUseCase.swift in Sources */,
+				C4E68C852C2A996000742464 /* AsynchronousError.swift in Sources */,
 				18AAF83E2A137349002EF441 /* CommunityResponseDTO.swift in Sources */,
 				41396D952A4EFF7B00B69341 /* MyInfo.swift in Sources */,
 				188F90C72A39FD7D003A1B4A /* UIImage+cornerRadius.swift in Sources */,

--- a/StreetDrop/StreetDrop/Data/Repositories/DefaultBlockUserRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/DefaultBlockUserRepository.swift
@@ -19,7 +19,13 @@ final class DefaultBlockUserRepository: BlockUserRepository {
 
 extension DefaultBlockUserRepository {
     func blockUser(_ blockUserID: Int) -> Single<Int> {
-        return networkManager.blockUser(blockUserID)
+        return networkManager.requestStatusCode(
+            target: .init(
+                NetworkService.blockUser(
+                    blockUserID: blockUserID
+                )
+            )
+        )
     }
 }
 

--- a/StreetDrop/StreetDrop/Data/Repositories/DefaultClaimCommentRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/DefaultClaimCommentRepository.swift
@@ -19,12 +19,15 @@ final class DefaultClaimCommentRepository: ClaimCommentRepository {
 
 extension DefaultClaimCommentRepository {
     func claimComment(itemID: Int, reason: String) -> Single<Int> {
-        let claimCommentRequestDTO = ClaimCommentRequestDTO(
-            itemID: itemID,
-            reason: reason
+        return networkManager.requestStatusCode(
+            target: .init(
+                NetworkService.claimComment(
+                    requestDTO: .init(
+                        itemID: itemID,
+                        reason: reason
+                    )
+                )
+            )
         )
-
-        return networkManager.claimComment(requestDTO: claimCommentRequestDTO)
     }
 }
-

--- a/StreetDrop/StreetDrop/Data/Repositories/DefaultDeleteMusicRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/DefaultDeleteMusicRepository.swift
@@ -19,6 +19,12 @@ final class DefaultDeleteMusicRepository: DeleteMusicRepository {
 
 extension DefaultDeleteMusicRepository {
     func deleteMusic(itemID: Int) -> Single<Int> {
-        return networkManager.deleteMusic(itemID: itemID)
+        return networkManager.requestStatusCode(
+            target: .init(
+                NetworkService.deleteMusic(
+                    itemID: itemID
+                )
+            )
+        )
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/DefaultDropMusicRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/DefaultDropMusicRepository.swift
@@ -18,20 +18,26 @@ final class DefaultDropMusicRepository {
 
 extension DefaultDropMusicRepository: DropMusicRepository {
     func dropMusic(droppingInfo: DroppingInfo, content: String) -> Single<Int> {
-        return networkManager.dropMusic(requestDTO: DropMusicRequestDTO(
-            location: DropMusicRequestDTO.Location(
-                latitude: droppingInfo.location.latitude,
-                longitude: droppingInfo.location.longitude,
-                address: droppingInfo.location.address
-            ),
-            music: DropMusicRequestDTO.Music(
-                title: droppingInfo.music.songName,
-                artist: droppingInfo.music.artistName,
-                albumName: droppingInfo.music.albumName,
-                albumImage: droppingInfo.music.albumImage,
-                genre: droppingInfo.music.genre
-            ),
-            content: content
-        ))
+        return networkManager.requestStatusCode(
+            target: .init(
+                NetworkService.dropMusic(
+                    requestDTO: .init(
+                        location: DropMusicRequestDTO.Location(
+                            latitude: droppingInfo.location.latitude,
+                            longitude: droppingInfo.location.longitude,
+                            address: droppingInfo.location.address
+                        ),
+                        music: DropMusicRequestDTO.Music(
+                            title: droppingInfo.music.songName,
+                            artist: droppingInfo.music.artistName,
+                            albumName: droppingInfo.music.albumName,
+                            albumImage: droppingInfo.music.albumImage,
+                            genre: droppingInfo.music.genre
+                        ),
+                        content: content
+                    )
+                )
+            )
+        )
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/DefaultEditCommentRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/DefaultEditCommentRepository.swift
@@ -19,9 +19,15 @@ final class DefaultEditCommentRepository: EditCommentRepository {
 
 extension DefaultEditCommentRepository {
     func editComment(itemID: Int, comment: String) -> Single<Int> {
-        return networkManager.editComment(
-            itemID: itemID,
-            requestDTO: EditCommentRequestDTO(content: comment)
+        return networkManager.requestStatusCode(
+            target: .init(
+                NetworkService.editComment(
+                    itemID: itemID,
+                    requestDTO: .init(
+                        content: comment
+                    )
+                )
+            )
         )
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/DefaultLikeMusicRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/DefaultLikeMusicRepository.swift
@@ -19,10 +19,22 @@ final class DefaultLikeMusicRepository: LikeMusicRepository {
 
 extension DefaultLikeMusicRepository {
     func likeUp(itemID: Int) -> Single<Int> {
-        return networkManager.postLikeUp(itemID: itemID)
+        return networkManager.requestStatusCode(
+            target: .init(
+                NetworkService.postLikeUp(
+                    itemID: itemID
+                )
+            )
+        )
     }
 
     func likeDown(itemID: Int) -> Single<Int> {
-        return networkManager.postLikeDown(itemID: itemID)
+        return networkManager.requestStatusCode(
+            target: .init(
+                NetworkService.postLikeDown(
+                    itemID: itemID
+                )
+            )
+        )
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/DefaultMyInfoRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/DefaultMyInfoRepository.swift
@@ -19,11 +19,15 @@ final class DefaultMyInfoRepository: MyInfoRepository {
     }
     
     func fetchMyInfoFromServer() -> Single<MyInfo> {
-        return networkManager.getMyInfo()
-            .map({ data in
-                let dto = try JSONDecoder().decode(MyInfoResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(
+                NetworkService.getMyInfo
+            ),
+            responseType: MyInfoResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
     
     func saveMyInfo(_ myInfo: MyInfo) -> Single<Void> {
@@ -47,11 +51,12 @@ final class DefaultMyInfoRepository: MyInfoRepository {
     }
     
     func fetchUserCircleRadius() -> Single<Double> {
-        return networkManager.getUserCircleRadius()
-            .map({ data in
-                let dto = try JSONDecoder().decode(UserCircleRadiusResponseDTO.self, from: data)
-                
-                return Double(dto.distance)
-            })
+        return networkManager.request(
+            target: .init(NetworkService.userCircleRadius),
+            responseType: UserCircleRadiusResponseDTO.self
+        )
+        .map { dto in
+            return Double(dto.distance)
+        }
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/DefaultPopUpRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/DefaultPopUpRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 import RxSwift
 
 final class DefaultPopUpRepository: PopUpRepository {
+    private struct EmptyResponse: Decodable {} // editNickName 메소드 responseType이 Void인데 해당 데이터타입이 Decodable를 준수하지 않아, 임의의 Decodable Struct 생성
     private let networkManager: NetworkManager
 
     init(networkManager: NetworkManager = .init()) {
@@ -17,17 +18,24 @@ final class DefaultPopUpRepository: PopUpRepository {
     }
     
     func fetchPopUpInfomation() -> Single<[PopUpInfomation]> {
-        return networkManager.getPopUpInfomation()
-            .map { data in
-                let dto = try JSONDecoder().decode(
-                    FetchingPopUpInfomationResponseDTO.self,
-                    from: data
-                )
-                return dto.toEntityList()
-            }
+        return networkManager.request(
+            target: .init(NetworkService.getPopUpInfomation),
+            responseType: FetchingPopUpInfomationResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntityList()
+        }
     }
     
     func postPopUpUserReading(type: String, id: Int) -> Single<Void> {
-        return networkManager.postPopUpUserReading(type: type, id: id)
+        return networkManager.request(
+            target: .init(
+                NetworkService.postPopUpUserReading(
+                    requestDTO: .init(type: type, id: id)
+                )
+            ),
+            responseType: EmptyResponse.self
+        )
+        .map { _ in Void() }
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/FCM/DefaultFCMRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/FCM/DefaultFCMRepository.swift
@@ -17,6 +17,12 @@ final class DefaultFCMRepository: FCMRepository {
     }
     
     func enrollFCMToken(token: String) -> Single<Int> {
-        return networkManager.postFCMToken(token: FCMTokenRequestDTO(token: token))
+        return networkManager.requestStatusCode(
+            target: .init(
+                NetworkService.postFCMToken(
+                    token: .init(token: token)
+                )
+            )
+        )
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/Main/DefaultMainRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/Main/DefaultMainRepository.swift
@@ -21,26 +21,49 @@ final class DefaultMainRepository: MainRepository {
 
 extension DefaultMainRepository {
     func fetchPoi(lat: Double, lon: Double, distacne: Double) -> Single<Pois> {
-        networkManager.getPoi(latitude: lat, longitude: lon, distance: distacne)
-            .map({ data in
-                let dto = try JSONDecoder().decode(PoiResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(
+                NetworkService.getPoi(
+                    latitude: lat,
+                    longitude: lon,
+                    distance: distacne
+                )
+            ),
+            responseType: PoiResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
     
     func fetchMusicCountByDong(lat: Double, lon: Double) -> Single<MusicCountEntity> {
-        networkManager.getMusicCountByDong(latitude: lat, longitude: lon)
-            .map({ data in
-                let dto = try JSONDecoder().decode(MusicCountByDongResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(
+                NetworkService.getMusicCountByDong(
+                    latitude: lat,
+                    longitude: lon
+                )
+            ),
+            responseType: MusicCountByDongResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
     
     func fetchMusicWithinArea(lat: Double, lon: Double, distacne: Double) -> Single<Musics> {
-        networkManager.getMusicWithinArea(latitude: lat, longitude: lon, distance: distacne)
-            .map({ data in
-                let dto = try JSONDecoder().decode(MusicWithinAreaResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(
+                NetworkService.getMusicWithinArea(
+                    latitude: lat,
+                    longitude: lon,
+                    distance: distacne
+                )
+            ),
+            responseType: MusicWithinAreaResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/Main/DefaultMainRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/Main/DefaultMainRepository.swift
@@ -20,13 +20,13 @@ final class DefaultMainRepository: MainRepository {
 }
 
 extension DefaultMainRepository {
-    func fetchPoi(lat: Double, lon: Double, distacne: Double) -> Single<Pois> {
+    func fetchPoi(lat: Double, lon: Double, distance: Double) -> Single<Pois> {
         return networkManager.request(
             target: .init(
                 NetworkService.getPoi(
                     latitude: lat,
                     longitude: lon,
-                    distance: distacne
+                    distance: distance
                 )
             ),
             responseType: PoiResponseDTO.self
@@ -51,13 +51,13 @@ extension DefaultMainRepository {
         }
     }
     
-    func fetchMusicWithinArea(lat: Double, lon: Double, distacne: Double) -> Single<Musics> {
+    func fetchMusicWithinArea(lat: Double, lon: Double, distance: Double) -> Single<Musics> {
         return networkManager.request(
             target: .init(
                 NetworkService.getMusicWithinArea(
                     latitude: lat,
                     longitude: lon,
-                    distance: distacne
+                    distance: distance
                 )
             ),
             responseType: MusicWithinAreaResponseDTO.self

--- a/StreetDrop/StreetDrop/Data/Repositories/MyPage/DefaultMyPageRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/MyPage/DefaultMyPageRepository.swift
@@ -19,53 +19,66 @@ final class DefaultMyPageRepository {
 
 extension DefaultMyPageRepository: MyPageRepository {
     func fetchMyDropList() -> Single<TotalMyMusics> {
-        networkManager.getMyDropList()
-            .map({ data in
-                let dto = try JSONDecoder().decode(MyDropListResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(NetworkService.myDropList),
+            responseType: MyDropListResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
     
     func fetchMyLikeList() -> Single<TotalMyMusics> {
-        networkManager.getMyLikeList()
-            .map({ data in
-                let dto = try JSONDecoder().decode(MyLikeListResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(NetworkService.myLikeList),
+            responseType: MyLikeListResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
     
     func fetchMyLevel() -> Single<MyLevel> {
-        networkManager.getMyLevel()
-            .map({ data in
-                let dto = try JSONDecoder().decode(MyLevelResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(NetworkService.myLevel),
+            responseType: MyLevelResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
     
     func fetchMyLevelProgress() -> Single<MyLevelProgress> {
-        networkManager.getMyLevelProgress()
-            .map({ data in
-                let dto = try JSONDecoder().decode(MyLevelProgressResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(NetworkService.myLevelProgress),
+            responseType: MyLevelProgressResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
     
     func fetchLevelPolicy() -> Single<[LevelPolicy]> {
-        networkManager.getLevelPolicy()
-            .map({ data in
-                let dto = try JSONDecoder().decode(LevelPolicyResponseDTO.self, from: data)
-                return dto.toEntity()
-            })
+        return networkManager.request(
+            target: .init(NetworkService.levelPolicy),
+            responseType: LevelPolicyResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
     
     func fetchMyDropMusic(itemID: Int) -> Single<Musics> {
-        networkManager.getSingleMusic(itemID: itemID)
-            .map({ data in
-                let dto = try JSONDecoder().decode(
-                    SingleMusicResponseDTO.self,
-                    from: data
+        return networkManager.request(
+            target: .init(
+                NetworkService.getSingleMusic(
+                    itemID: itemID
                 )
-                return dto.toEntity()
-            })
+            ),
+            responseType: SingleMusicResponseDTO.self
+        )
+        .map { dto in
+            return dto.toEntity()
+        }
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/MyPage/DefaultNicknameEditRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/MyPage/DefaultNicknameEditRepository.swift
@@ -18,7 +18,13 @@ final class DefaultNicknameEditRepository: NicknameEditRepository {
 }
 
 extension DefaultNicknameEditRepository {
+    private struct EmptyResponse: Decodable {} // editNickName 메소드 responseType이 Void인데 해당 데이터타입이 Decodable를 준수하지 않아, 임의의 Decodable Struct 생성
+    
     func editNickname(nickname: String) -> Single<Void> {
-        networkManager.editNickname(nickname: nickname)
+        return networkManager.request(
+            target: .init(NetworkService.editNickname(nickname: nickname)),
+            responseType: EmptyResponse.self
+        )
+        .map { _ in Void() }
     }
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/Protocol/Main/MainRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/Protocol/Main/MainRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 protocol MainRepository {
-    func fetchPoi(lat: Double, lon: Double, distacne: Double) -> Single<Pois>
+    func fetchPoi(lat: Double, lon: Double, distance: Double) -> Single<Pois>
     func fetchMusicCountByDong(lat: Double, lon: Double) -> Single<MusicCountEntity>
-    func fetchMusicWithinArea(lat: Double, lon: Double, distacne: Double) -> Single<Musics>
+    func fetchMusicWithinArea(lat: Double, lon: Double, distance: Double) -> Single<Musics>
 }

--- a/StreetDrop/StreetDrop/Data/Repositories/Setting/DefaultSettingsRepository.swift
+++ b/StreetDrop/StreetDrop/Data/Repositories/Setting/DefaultSettingsRepository.swift
@@ -82,9 +82,14 @@ final class DefaultSettingsRepository: SettingsRepository {
     }
     
     func checkNewNotice(lastNoticeId: Int?) -> Single<Bool> {
-        networkManager.checkNewNotice(lastNoticeId: lastNoticeId)
-            .map({ noticeUpdate in
-                return noticeUpdate.hasNewNotice
-            })
+        return networkManager.request(
+            target: .init(
+                NetworkService.checkNewNotice(
+                    lastNoticeId: lastNoticeId
+                )
+            ),
+            responseType: NoticeUpdateDTO.self
+        )
+        .map(\.hasNewNotice)
     }
 }

--- a/StreetDrop/StreetDrop/Domain/UseCase/DefaultFetchingMusicWithinArea.swift
+++ b/StreetDrop/StreetDrop/Domain/UseCase/DefaultFetchingMusicWithinArea.swift
@@ -20,6 +20,6 @@ final class DefaultFetchingMusicWithinArea: FetchingMusicWithinArea {
     }
     
     func execute(lat: Double, lon: Double, distance: Double) -> Single<Musics> {
-        return mainRepository.fetchMusicWithinArea(lat: lat, lon: lon, distacne: distance)
+        return mainRepository.fetchMusicWithinArea(lat: lat, lon: lon, distance: distance)
     }
 }

--- a/StreetDrop/StreetDrop/Domain/UseCase/DefaultFetchingPOIUseCase.swift
+++ b/StreetDrop/StreetDrop/Domain/UseCase/DefaultFetchingPOIUseCase.swift
@@ -20,6 +20,6 @@ final class DefaultFetchingPOIUseCase: FetchingPOIUseCase {
     }
     
     func execute(lat: Double, lon: Double, distance: Double) -> Single<Pois> {
-        return mainRepository.fetchPoi(lat: lat, lon: lon, distacne: distance)
+        return mainRepository.fetchPoi(lat: lat, lon: lon, distance: distance)
     }
 }

--- a/StreetDrop/StreetDrop/Network/NetworkManager.swift
+++ b/StreetDrop/StreetDrop/Network/NetworkManager.swift
@@ -12,199 +12,23 @@ import RxSwift
 import RxMoya
 
 struct NetworkManager {
-    var provider = MoyaProvider<NetworkService>()
-    let disposeBag = DisposeBag()
+    private let provider: MoyaProvider<MultiTarget>
     
-    init(provider: MoyaProvider<NetworkService> = MoyaProvider()) {
+    init(
+        provider: MoyaProvider<MultiTarget> = .init()
+    ) {
         self.provider = provider
     }
     
-    func getMyInfo() -> Single<Data> {
-        return provider.rx.request(.getMyInfo)
+    func request<U: Decodable>(target: MultiTarget, responseType: U.Type) -> Single<U> {
+        return provider.rx.request(target)
             .retry(3)
-            .map { $0.data }
+            .filterSuccessfulStatusCodes()
+            .map(U.self)
     }
     
-    func searchMusic(keyword: String) -> Single<Data> {
-        return provider.rx.request(.searchMusic(keyword: keyword))
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getRecommendMusic() -> Single<Data> {
-        return provider.rx.request(.recommendMusic).retry(3).map { $0.data }
-    }
-    
-    func dropMusic(requestDTO: DropMusicRequestDTO) -> Single<Int> {
-        return provider.rx.request(.dropMusic(requestDTO: requestDTO))
-            .retry(3)
+    func requestStatusCode(target: MultiTarget) -> Single<Int> {
+        return provider.rx.request(target)
             .map { $0.statusCode }
-    }
-    
-    func getSingleMusic(itemID: Int) -> Single<Data> {
-        return provider.rx
-            .request(.getSingleMusic(itemID: itemID))
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getMusicCountByDong(latitude: Double, longitude: Double) -> Single<Data> {
-        return provider.rx
-            .request(.getMusicCountByDong(latitude: latitude, longitude: longitude))
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getMusicWithinArea(latitude: Double, longitude: Double, distance: Double) -> Single<Data> {
-        return provider.rx
-            .request(.getMusicWithinArea(latitude: latitude, longitude: longitude, distance: distance))
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getCommunity(itemID: UUID) -> Single<Data> {
-        return provider.rx.request(.getCommunity(itemID: itemID))
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getPoi(latitude: Double, longitude: Double, distance: Double) -> Single<Data> {
-        return provider.rx
-            .request(.getPoi(latitude: latitude, longitude: longitude, distance: distance))
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func postLikeUp(itemID: Int) -> Single<Int> {
-        return provider.rx.request(.postLikeUp(itemID: itemID))
-            .retry(3)
-            .map { $0.statusCode }
-    }
-    
-    func postLikeDown(itemID: Int) -> Single<Int> {
-        return provider.rx.request(.postLikeDown(itemID: itemID))
-            .retry(3)
-            .map { $0.statusCode }
-    }
-    
-    func claimComment(requestDTO: ClaimCommentRequestDTO) -> Single<Int> {
-        return provider.rx.request(.claimComment(requestDTO: requestDTO))
-            .retry(3)
-            .map { $0.statusCode }
-    }
-    
-    func editComment(itemID: Int, requestDTO: EditCommentRequestDTO) -> Single<Int> {
-        return provider.rx.request(.editComment(itemID: itemID, requestDTO: requestDTO))
-            .retry(3)
-            .map { $0.statusCode }
-    }
-    
-    func deleteMusic(itemID: Int) -> Single<Int> {
-        return provider.rx.request(.deleteMusic(itemID: itemID))
-            .retry(3)
-            .map { $0.statusCode }
-    }
-    
-    func getVillageName(latitude: Double, longitude: Double) -> Single<Data> {
-        return provider.rx.request(.getVillageName(latitude: latitude, longitude: longitude))
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func blockUser(_ blockUserID: Int) -> Single<Int> {
-        return provider.rx.request(.blockUser(blockUserID: blockUserID))
-            .retry(3)
-            .map { $0.statusCode }
-    }
-    
-    func postFCMToken(token: FCMTokenRequestDTO) -> Single<Int> {
-        return provider.rx.request(.postFCMToken(token: token))
-            .retry(3)
-            .map { $0.statusCode }
-    }
-    
-    func patchUsersMusicApp(musicAppQueryString: String) -> Single<Data> {
-        return provider.rx.request(.patchUsersMusicApp(musicAppQuery: musicAppQueryString))
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getMyDropList() -> Single<Data> {
-        return provider.rx.request(.myDropList)
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getMyLikeList() -> Single<Data> {
-        return provider.rx.request(.myLikeList)
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getMyLevel() -> Single<Data> {
-        return provider.rx.request(.myLevel)
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getMyLevelProgress() -> Single<Data> {
-        return provider.rx.request(.myLevelProgress)
-            .map { $0.data }
-            .retry(3)
-    }
-    
-    func getLevelPolicy() -> Single<Data> {
-        return provider.rx.request(.levelPolicy)
-            .map { $0.data }
-            .retry(3)
-    }
-    
-    func editNickname(nickname: String) -> Single<Void> {
-        return provider.rx.request(.editNickname(nickname: nickname))
-            .retry(3)
-            .map { _ in }
-    }
-    
-    func getUserCircleRadius() -> Single<Data> {
-        return provider.rx.request(.userCircleRadius)
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func getPopUpInfomation() -> Single<Data> {
-        return provider.rx.request(.getPopUpInfomation)
-            .retry(3)
-            .map { $0.data }
-    }
-    
-    func postPopUpUserReading(type: String, id: Int) -> Single<Void> {
-        return provider.rx.request(
-            .postPopUpUserReading(
-                requestDTO: .init(
-                    type: type,
-                    id: id
-                )
-            )
-        )
-        .retry(3)
-        .map { _ in }
-    }
-    
-    func getNoticeList() -> Single<NoticeListResponseDTO> {
-        return provider.rx.request(.getNoticeList)
-        .retry(3)
-        .map(NoticeListResponseDTO.self)
-    }
-    
-    func getNoticeDetail(id: Int) -> Single<NoticeDetailDTO> {
-        return provider.rx.request(.getNoticeDetail(id: id))
-        .retry(3)
-        .map(NoticeDetailDTO.self)
-    }
-    
-    func checkNewNotice(lastNoticeId: Int?) -> Single<NoticeUpdateDTO> {
-        return provider.rx.request(.checkNewNotice(lastNoticeId: lastNoticeId))
-        .retry(3)
-        .map(NoticeUpdateDTO.self)
     }
 }

--- a/StreetDrop/StreetDrop/Util/Error/AsynchronousError.swift
+++ b/StreetDrop/StreetDrop/Util/Error/AsynchronousError.swift
@@ -1,0 +1,21 @@
+//
+//  AsynchronousError.swift
+//  StreetDrop
+//
+//  Created by 차요셉 on 6/25/24.
+//
+
+import Foundation
+
+enum AsynchronousError: Error {
+    case closureSelfDeInitiation
+}
+
+extension AsynchronousError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .closureSelfDeInitiation:
+            return "클로저 속 self 객체가 deInit 되었습니다."
+        }
+    }
+}


### PR DESCRIPTION
## 📌 배경

close #288 

## 내용
- ### **이전 네트워크 로직 문제점**
  ![image](https://github.com/depromeet/street-drop-iOS/assets/35060252/0b34dabf-f40e-40cf-93df-483b80b4edda)
  - API 통신 로직 추가해야할때마다, NetworkManager에 해당 API에 대한 Request 메소드를 작성했어야 했음
  - 또한 매번 NetworkManager API 메소드들의 반환값을 Data로 하고 Repository 레이어에서 디코딩하는 불필요한 행동을 했음 (일부 제외)

- ### **리팩토링한 네트워크 로직 설명**
  ![image](https://github.com/depromeet/street-drop-iOS/assets/35060252/69b7a196-458f-4c79-a21a-cf79a209783b)
  - 파라미터와 반환값을 제네릭 하게 리팩토링하여, API Request 작성 시 **재사용 가능하도록 함**. `// func request<U: Decodable>(target: MultiTarget, responseType: U.Type) -> Single<U>`
    - **MultiTarget** 파라미터는 TargetType을 준수하는 **모든 API enum Case들을 수용**할 수 있는 제네릭 enum (Moya에서 제공)
    - responseType 파라미터는 API Response 값에 대해 디코딩 되길 원하는 ResponseDTO 타입을 지정
      - 기존처럼 Data타입으로 반환하고 Repository들에서 디코딩하지 않고, 해당 로직을 통해 디코딩 함 -> `.map(U.self)`
      
  - 기존 Response Data말고 StatusCode을 받아 처리하는 로직은 `// func requestStatusCode(target: MultiTarget) -> Single<Int>`

- ### **사용 방법**  
  ![image](https://github.com/depromeet/street-drop-iOS/assets/35060252/266fda81-c9d5-4ef2-9821-9ba20a77226e)
  - target(MultiTarget) 파라미터에 전달인자로 원하는 TargetType를 준수하는 API enum Case를 주입한 MultiTarget 인스턴스를 전달
    ![image](https://github.com/depromeet/street-drop-iOS/assets/35060252/6edc46b0-db46-4690-8609-49819caa8d39)
  - responseType 파라미터에 디코딩되어 반환되길 원하는 ResponseDTO (Decodable 프로토콜 준수)를 지정
  - 반환된 ResponseDTO를 사용하면됨. 예시에서는 ResponseDTO를 Pois라는 엔티티로 매핑하고 있음

## 테스트 방법 (optional)
- 전체 기능 테스트 (네트워크 API 통신하는 부분 리팩토링 했기에)