### PR TITLE
공지사항 디테일 화면 - 마크다운 처리

### DIFF
--- a/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
+++ b/StreetDrop/StreetDrop.xcodeproj/project.pbxproj
@@ -2194,6 +2194,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2237,6 +2238,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/StreetDrop/StreetDrop/Util/Extensions/UIImage+loadURLImage.swift
+++ b/StreetDrop/StreetDrop/Util/Extensions/UIImage+loadURLImage.swift
@@ -35,4 +35,21 @@ extension UIImage {
             return Disposables.create()
         }
     }
+    
+    static func load(with urlString: String) async throws -> UIImage {
+        guard let url = URL(string: urlString) else {
+            throw ImageCacheError.invalidURLError
+        }
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            KingfisherManager.shared.retrieveImage(with: url, options: nil, progressBlock: nil) { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value.image)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 📌 공지사항 마크다운 처리

## 내용
마크다운으로 작성된 공지사항 내용을 문법에 맞게 렌더링하여 보여줄 수 있도록 합니다
이미지 변환은 자동으로 해주지 않아서 별도로 구현하였습니다
(마크다운 변환은 iOS15 이상에서만 지원하여 최소버전을 15로 올렸습니다)

## 스크린샷
<img src="https://github.com/depromeet/street-drop-iOS/assets/171426798/12a0bfc9-7715-451a-af47-6792b422ba5b" width=200>

